### PR TITLE
🔧 パッケージの取得先をsabera-sdk-packagesに向ける

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,12 +27,13 @@ jobs:
           java-version: '17'
           cache: gradle
 
-      # SDK は同じリポジトリの GitHub Packages にあるので GITHUB_TOKEN で取れる
+      # SDK は jig-SABERA/sabera-sdk-packages にある。GITHUB_TOKEN は自リポジトリの
+      # パッケージしか読めないため、read:packages を持つ PAT を Secrets から渡す
       - name: コード例をコンパイルする
         working-directory: samples/kmp
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SDK_PACKAGES_TOKEN }}
         run: ./gradlew --no-daemon :snippets:compileDebugKotlin :snippets:ktlintCheck
 
       - name: docs のコード例が最新か確かめる

--- a/Package.swift
+++ b/Package.swift
@@ -2,8 +2,8 @@
 import PackageDescription
 
 // BEGIN KMMBRIDGE VARIABLES BLOCK (do not edit)
-let remoteKotlinUrl = "https://maven.pkg.github.com/jig-jp/sabera-sdk/jp/jig/sabera/app/sdk/sabera-app-core-kmmbridge/0.0.10/sabera-app-core-kmmbridge-0.0.10.zip"
-let remoteKotlinChecksum = "44ce24aeff87374711d117dbb68055ff86920ef10a43c504f5da9e7a14b70026"
+let remoteKotlinUrl = "https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages/jp/jig/sabera/app/sdk/sabera-app-core-kmmbridge/0.0.10/sabera-app-core-kmmbridge-0.0.10.zip"
+let remoteKotlinChecksum = "cbc08c64ca54f362882e28e4105ba610ccce993563724d83454f6ecb4509bf02"
 let packageName = "SaberaAppSDK"
 // END KMMBRIDGE BLOCK
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sabera App SDK の使い方を示すサンプルアプリ集。
 
 ## 前提条件
 
-SDK は GitHub Packages (`jig-jp/sabera-sdk`) から取得する。private パッケージのため、
+SDK は GitHub Packages (`jig-SABERA/sabera-sdk-packages`) から取得する。private パッケージのため、
 `read:packages` スコープを持つ PAT を `~/.gradle/gradle.properties` に設定しておく。
 
 ```properties

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@ search:
   focus_shortcut_key: 'k'
 
 aux_links:
-  GitHub: https://github.com/jig-jp/sabera-sdk
+  GitHub: https://github.com/jig-SABERA/sabera-sdk
 
 exclude:
   - Gemfile

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -69,7 +69,7 @@ python3 scripts/gen-api-docs.py
 ```console
 # 0.0.10 の AAR を GitHub Packages から取る
 curl -sL -u "<user>:<PAT>" -o core.aar \
-  https://maven.pkg.github.com/jig-jp/sabera-sdk/jp/jig/sabera/app/sdk/sabera-app-core-android/0.0.10/sabera-app-core-android-0.0.10.aar
+  https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages/jp/jig/sabera/app/sdk/sabera-app-core-android/0.0.10/sabera-app-core-android-0.0.10.aar
 unzip -o core.aar -d aar && unzip -o aar/classes.jar -d cls
 javap -public cls/app/jigglass/glass/CommandManager.class
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ SDKはネイティブAPIとして提供している。
 
 ## SDK の取得設定
 
-SDK は GitHub Packages (`jig-jp/sabera-sdk`) で配布している。private
+SDK は GitHub Packages (`jig-SABERA/sabera-sdk-packages`) で配布している。private
 パッケージなので、取得には `read:packages` スコープを持つ Personal Access Token
 が必要。発行手順は [GitHub PAT の作り方](github-pat.html) を参照。
 

--- a/docs/github-pat.md
+++ b/docs/github-pat.md
@@ -31,7 +31,7 @@ GitHub にログインした状態で
 ## 2. SSO を認可する（表示されている場合のみ）
 
 トークン一覧に **Configure SSO** ボタンが出ている場合、Organization が SAML SSO を
-使っている。発行しただけではパッケージを取得できないので、ボタンを押して `jig-jp` を
+使っている。発行しただけではパッケージを取得できないので、ボタンを押して `jig-SABERA` を
 **Authorize** する。これを忘れると `401 Unauthorized` になる。
 
 ## 3. Gradle に設定する

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,5 +15,5 @@ nav_order: 1
 
 | サンプル | プラットフォーム | 説明 |
 |---|---|---|
-| [Flutter](https://github.com/jig-jp/sabera-sdk/tree/main/samples/flutter) | Android | MethodChannel / EventChannel 経由で Dart から操作 |
-| [KMP](https://github.com/jig-jp/sabera-sdk/tree/main/samples/kmp) | Android / iOS | Kotlin Multiplatform から直接利用 |
+| [Flutter](https://github.com/jig-SABERA/sabera-sdk/tree/main/samples/flutter) | Android | MethodChannel / EventChannel 経由で Dart から操作 |
+| [KMP](https://github.com/jig-SABERA/sabera-sdk/tree/main/samples/kmp) | Android / iOS | Kotlin Multiplatform から直接利用 |

--- a/samples/flutter/android/build.gradle.kts
+++ b/samples/flutter/android/build.gradle.kts
@@ -3,7 +3,7 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url = uri("https://maven.pkg.github.com/jig-jp/sabera-sdk")
+            url = uri("https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages")
             credentials {
                 username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
                 password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")

--- a/samples/kmp/settings.gradle.kts
+++ b/samples/kmp/settings.gradle.kts
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url = uri("https://maven.pkg.github.com/jig-jp/sabera-sdk")
+            url = uri("https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages")
             credentials {
                 username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
                 password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")


### PR DESCRIPTION
## 何を直したか

`:snippets:compileDebugKotlin` が `jp.jig.sabera.app.sdk:sabera-app-core:0.0.10` を解決できず落ちていた。SDK の Maven パッケージの置き場が `jig-SABERA/sabera-sdk-packages` に移ったため。

- サンプル 2 つの Maven リポジトリ URL を新しい配布先に変更
- ドキュメント / README の配布元表記と GitHub リンクを更新（SSO 認可先も `jig-SABERA`）
- `Package.swift` を新しい配布先の 0.0.10（URL と checksum）に更新
- Docs ワークフローの認証を `GITHUB_TOKEN` から `secrets.SDK_PACKAGES_TOKEN` に変更

## 必要な設定

パッケージが別リポジトリになったため `GITHUB_TOKEN` では読めない。**このリポジトリの Secrets に `read:packages` を持つ PAT を `SDK_PACKAGES_TOKEN` として登録するまで CI は通らない。**

## 確認したこと

手元で新しい配布先から 0.0.10 を解決して `:snippets:compileDebugKotlin :snippets:ktlintCheck` が BUILD SUCCESSFUL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)