### PR TITLE
🎨 取得用の認証情報をGradle標準のcredentials providerで受け取る

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,8 +32,8 @@ jobs:
       - name: コード例をコンパイルする
         working-directory: samples/kmp
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.SDK_PACKAGES_TOKEN }}
+          ORG_GRADLE_PROJECT_GitHubPackagesUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_GitHubPackagesPassword: ${{ secrets.SDK_PACKAGES_TOKEN }}
         run: ./gradlew --no-daemon :snippets:compileDebugKotlin :snippets:ktlintCheck
 
       - name: docs のコード例が最新か確かめる

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ SDK は GitHub Packages (`jig-SABERA/sabera-sdk-packages`) から取得する。
 `read:packages` スコープを持つ PAT を `~/.gradle/gradle.properties` に設定しておく。
 
 ```properties
-gpr.user=<GitHubのユーザー名>
-gpr.token=<read:packages を持つ PAT>
+GitHubPackagesUsername=<GitHubのユーザー名>
+GitHubPackagesPassword=<read:packages を持つ PAT>
 ```
 
 詳細は [Getting Started](docs/getting-started.md) を参照。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,14 +14,22 @@ SDK は GitHub Packages (`jig-SABERA/sabera-sdk-packages`) で配布している
 パッケージなので、取得には `read:packages` スコープを持つ Personal Access Token
 が必要。発行手順は [GitHub PAT の作り方](github-pat.html) を参照。
 
-`~/.gradle/gradle.properties` に認証情報を書く。
+`~/.gradle/gradle.properties` に認証情報を書く。全プロジェクトで共有される。
 
 ```properties
-gpr.user=<GitHubのユーザー名>
-gpr.token=<read:packages を持つ PAT>
+GitHubPackagesUsername=<GitHubのユーザー名>
+GitHubPackagesPassword=<read:packages を持つ PAT>
 ```
 
-環境変数 `GITHUB_ACTOR` / `GITHUB_TOKEN` でも代用できる。
+プロパティ名は `settings.gradle.kts` でリポジトリに付けた名前（`GitHubPackages`）から
+決まる。Gradle の credentials provider が探す名前なので、変えると認証されない。
+
+CI では環境変数で渡す。プロパティ名の前に `ORG_GRADLE_PROJECT_` を付ける。
+
+```bash
+ORG_GRADLE_PROJECT_GitHubPackagesUsername=<GitHubのユーザー名>
+ORG_GRADLE_PROJECT_GitHubPackagesPassword=<read:packages を持つ PAT>
+```
 
 ## 全体の流れ
 

--- a/docs/github-pat.md
+++ b/docs/github-pat.md
@@ -40,15 +40,15 @@ GitHub にログインした状態で
 リポジトリにコミットしてしまう事故を防ぐため。
 
 ```properties
-gpr.user=<GitHubのユーザー名>
-gpr.token=<発行した PAT>
+GitHubPackagesUsername=<GitHubのユーザー名>
+GitHubPackagesPassword=<発行した PAT>
 ```
 
 環境変数でも代用できる。CI ではこちらを使う。
 
 ```bash
-export GITHUB_ACTOR=<GitHubのユーザー名>
-export GITHUB_TOKEN=<発行した PAT>
+export ORG_GRADLE_PROJECT_GitHubPackagesUsername=<GitHubのユーザー名>
+export ORG_GRADLE_PROJECT_GitHubPackagesPassword=<発行した PAT>
 ```
 
 ## 4. 確認する
@@ -61,7 +61,7 @@ export GITHUB_TOKEN=<発行した PAT>
 - **403 Forbidden** — スコープに `read:packages` が入っていない
 - **依存が見つからない** — `gradle.properties` の場所が違う。
   `~/.gradle/gradle.properties` に置く
-- **認証情報が空のまま** — `gpr.user` は GitHub のユーザー名。メールアドレスではない
+- **認証情報が空のまま** — `GitHubPackagesUsername` は GitHub のユーザー名。メールアドレスではない
 
 ## Fine-grained token について
 

--- a/samples/flutter/android/build.gradle.kts
+++ b/samples/flutter/android/build.gradle.kts
@@ -2,12 +2,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // 認証情報は名前から決まる GitHubPackagesUsername / GitHubPackagesPassword を
+        // Gradle が探す。設定キャッシュには保存されず、必要になるまで要求もされない。
         maven {
+            name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages")
-            credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")
-            }
+            credentials(PasswordCredentials::class)
         }
     }
 }

--- a/samples/kmp/settings.gradle.kts
+++ b/samples/kmp/settings.gradle.kts
@@ -12,12 +12,12 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // 認証情報は名前から決まる GitHubPackagesUsername / GitHubPackagesPassword を
+        // Gradle が探す。設定キャッシュには保存されず、必要になるまで要求もされない。
         maven {
+            name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages")
-            credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")
-            }
+            credentials(PasswordCredentials::class)
         }
     }
 }


### PR DESCRIPTION
## 何をしたか

SDK 取得時の認証情報の受け取りを、独自キー `gpr.user` / `gpr.token` の自前読み込みから、Gradle 標準の credentials provider に置き換えた。

```kotlin
maven {
    name = "GitHubPackages"
    url = uri("https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages")
    credentials(PasswordCredentials::class)
}
```

リポジトリ名から決まる `GitHubPackagesUsername` / `GitHubPackagesPassword` を Gradle が自分で探すため、プロパティを読むコードが要らなくなる。認証情報が設定キャッシュのエントリに保存されないのも利点。

- サンプル 2 つのリポジトリ定義を credentials provider に変更
- Docs ワークフローの環境変数を `ORG_GRADLE_PROJECT_GitHubPackagesUsername` / `...Password` に変更
- README・Getting Started・GitHub PAT の手順のプロパティ名と環境変数を更新

## 確認したこと

`--configuration-cache --refresh-dependencies` 付きで 2 通り検証し、どちらも BUILD SUCCESSFUL かつ設定キャッシュのエントリが保存された。

- `~/.gradle/gradle.properties` に `GitHubPackagesUsername` / `GitHubPackagesPassword` を書いた場合
- `ORG_GRADLE_PROJECT_*` 環境変数だけを渡した場合（CI と同じ経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)