### PR TITLE
👍️ 画像表示をSDKから試せるようにする

### DIFF
--- a/docs/api/command-manager/enter-image-display-page.md
+++ b/docs/api/command-manager/enter-image-display-page.md
@@ -22,7 +22,10 @@ fun enterImageDisplayPage()
 ## 使用例
 
 <!-- snippet: CommandManager.enterImageDisplayPage -->
-<!-- WIP -->
+```kotlin
+// 技適マークの表示にも使っている画像表示ページ
+commandManager.enterImageDisplayPage()
+```
 <!-- /snippet -->
 
 ## 関連

--- a/docs/api/command-manager/index.md
+++ b/docs/api/command-manager/index.md
@@ -63,7 +63,7 @@ fun sendTeleprompterContent(content: String, percent: Int)` |
 | [clearInscriptionText](clear-inscription-text.html) | `fun clearInscriptionText()` |
 | [sendEmptyScreenContent](send-empty-screen-content.html) | `fun sendEmptyScreenContent(content: String)` |
 | [sendEmptyScreenStatus](send-empty-screen-status.html) | `fun sendEmptyScreenStatus(status: CommandManager.TeleprompterStatus)` |
-| [sendImage](send-image.html) | `fun sendImage(width: Int, height: Int, encodedBitmap: ByteArray)` |
+| [sendImage](send-image.html) | `fun sendImage(width: Int, height: Int, grayscale: ByteArray)` |
 | [sendAiChatLanguage](send-ai-chat-language.html) | `fun sendAiChatLanguage(languageCode: String)` |
 | [clearAiChat](clear-ai-chat.html) | `fun clearAiChat()` |
 | [clearAiChatLegacy](clear-ai-chat-legacy.html) | `fun clearAiChatLegacy()` |

--- a/docs/api/command-manager/send-image.md
+++ b/docs/api/command-manager/send-image.md
@@ -8,12 +8,12 @@ nav_order: 41
 # CommandManager.sendImage
 
 ```kotlin
-fun sendImage(width: Int, height: Int, encodedBitmap: ByteArray)
+fun sendImage(width: Int, height: Int, grayscale: ByteArray)
 ```
 
 ## 概要
 
-画像表示ページに画像を送る。enterImageDisplayPage で開いてから呼ぶ。ビットマップは3bitグレースケールをRLE圧縮したバイト列で、エンコードは呼び出し側で行う。グラス側のバッファは静的で、196x196 を超えるサイズはファーム側で弾かれ、何も表示されない。
+画像表示ページに画像を送る。enterImageDisplayPage で開いてから呼ぶ。渡すのはリサイズ済みのグレースケールで、1画素1バイト・左上から行優先の並び。輝度は 0-255 のままでよく、グラスが読む3bitへの量子化とRLE圧縮は SDK が行う。グラス側のバッファは静的で、196x196 を超えるサイズはファーム側で弾かれ、何も表示されない。
 
 ## 引数
 
@@ -21,7 +21,7 @@ fun sendImage(width: Int, height: Int, encodedBitmap: ByteArray)
 |---|---|---|
 | `width` | `Int` | 画像の幅。196まで |
 | `height` | `Int` | 画像の高さ。196まで |
-| `encodedBitmap` | `ByteArray` | エンコード済みの画像データ |
+| `grayscale` | `ByteArray` | 1画素1バイトのグレースケール。長さは `width * height` 以上 |
 
 ## 戻り値
 

--- a/docs/api/command-manager/send-image.md
+++ b/docs/api/command-manager/send-image.md
@@ -30,7 +30,11 @@ fun sendImage(width: Int, height: Int, grayscale: ByteArray)
 ## 使用例
 
 <!-- snippet: CommandManager.sendImage -->
-<!-- WIP -->
+```kotlin
+commandManager.enterImageDisplayPage()
+// grayscale は1画素1バイト・左上から行優先。3bitへの量子化とRLE圧縮はSDKが行う
+commandManager.sendImage(width = 196, height = 196, grayscale = grayscale)
+```
 <!-- /snippet -->
 
 ## 関連

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,7 +6,7 @@ has_children: true
 
 # API リファレンス
 
-Sabera App SDK (Kotlin) の公開 API。バージョン 0.0.11 時点。
+Sabera App SDK (Kotlin) の公開 API。バージョン 0.0.12 時点。
 
 | 型 | 説明 |
 |---|---|

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -70,9 +70,9 @@ python3 scripts/gen-api-docs.py
 シグネチャは AAR を読んで確定させる。
 
 ```console
-# 0.0.11 の AAR を GitHub Packages から取る
+# 0.0.12 の AAR を GitHub Packages から取る
 curl -sL -u "<user>:<PAT>" -o core.aar \
-  https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages/jp/jig/sabera/app/sdk/sabera-app-core-android/0.0.11/sabera-app-core-android-0.0.11.aar
+  https://maven.pkg.github.com/jig-SABERA/sabera-sdk-packages/jp/jig/sabera/app/sdk/sabera-app-core-android/0.0.12/sabera-app-core-android-0.0.12.aar
 unzip -o core.aar -d aar && unzip -o aar/classes.jar -d cls
 javap -public cls/app/jigglass/glass/CommandManager.class
 ```

--- a/samples/flutter/android/app/build.gradle.kts
+++ b/samples/flutter/android/app/build.gradle.kts
@@ -42,6 +42,6 @@ flutter {
 }
 
 dependencies {
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.11")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.12")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/samples/kmp/app/build.gradle.kts
+++ b/samples/kmp/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Sabera App SDK
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.11")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.12")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Compose

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -40,7 +40,7 @@ private const val TAG = "CommandScreen"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CommandScreen(manager: GlassManager, client: GlassClient) {
+fun CommandScreen(manager: GlassManager, client: GlassClient, onOpenImageScreen: () -> Unit) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
 
@@ -93,6 +93,7 @@ fun CommandScreen(manager: GlassManager, client: GlassClient) {
             CommandButton("AI アシスタントを開く") { safeRun("enterAiChatPage") { commandManager.enterAiChatPage() } }
             CommandButton("AI ページを開く（旧 UI）") { safeRun("enterAIPage") { commandManager.enterAIPage(false) } }
             CommandButton("翻訳ページを開く") { safeRun("enterTranslatePage") { commandManager.enterTranslatePage() } }
+            CommandButton("画像を送る画面へ", onClick = onOpenImageScreen)
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassImage.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassImage.kt
@@ -1,0 +1,59 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color
+
+/** グラスに送れる形に整えた画像。1画素1バイトのグレースケール */
+data class GrayscaleImage(
+    val width: Int,
+    val height: Int,
+    val pixels: ByteArray,
+) {
+    /** プレビュー表示用に Bitmap へ戻す */
+    fun toBitmap(): Bitmap {
+        val colors = IntArray(width * height) { index ->
+            val value = pixels[index].toInt() and 0xFF
+            Color.rgb(value, value, value)
+        }
+        return Bitmap.createBitmap(colors, width, height, Bitmap.Config.ARGB_8888)
+    }
+}
+
+/** グラス側のバッファ上限。これを超えるサイズはファームが弾いて何も表示されない */
+const val GLASS_IMAGE_MAX_SIZE = 196
+
+/**
+ * グラスに送れるサイズ・形式へ整える。
+ * 縦横比は保ったまま [GLASS_IMAGE_MAX_SIZE] に収まるよう縮小し、輝度だけを取り出す。
+ */
+fun Bitmap.toGlassGrayscale(maxSize: Int = GLASS_IMAGE_MAX_SIZE): GrayscaleImage {
+    val scale = minOf(maxSize.toFloat() / width, maxSize.toFloat() / height, 1f)
+    val scaledWidth = (width * scale).toInt().coerceAtLeast(1)
+    val scaledHeight = (height * scale).toInt().coerceAtLeast(1)
+    val scaled = Bitmap.createScaledBitmap(this, scaledWidth, scaledHeight, true)
+
+    val colors = IntArray(scaledWidth * scaledHeight)
+    scaled.getPixels(colors, 0, scaledWidth, 0, 0, scaledWidth, scaledHeight)
+
+    val pixels = ByteArray(colors.size) { index ->
+        val color = colors[index]
+        val luminance = 0.299 * Color.red(color) +
+            0.587 * Color.green(color) +
+            0.114 * Color.blue(color)
+        luminance.toInt().coerceIn(0, 255).toByte()
+    }
+    return GrayscaleImage(scaledWidth, scaledHeight, pixels)
+}
+
+/** 画像を選ばずに送信を試せるテストパターン。左右のグラデーションに市松模様を重ねる */
+fun testPatternImage(size: Int = GLASS_IMAGE_MAX_SIZE): GrayscaleImage {
+    val block = size / 8
+    val pixels = ByteArray(size * size) { index ->
+        val x = index % size
+        val y = index / size
+        val gradient = x * 255 / (size - 1)
+        val inverted = (x / block + y / block) % 2 == 0
+        (if (inverted) gradient else 255 - gradient).toByte()
+    }
+    return GrayscaleImage(size, size, pixels)
+}

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -3,19 +3,37 @@ package jp.jig.glasses.sample.kmp.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import app.jigglass.glass.GlassManager
+
+private enum class ConnectedScreen {
+    COMMAND,
+    IMAGE,
+}
 
 @Composable
 fun GlassesApp(manager: GlassManager) {
     val client by manager.connectedDevice.collectAsState(initial = null)
+    var screen by remember { mutableStateOf(ConnectedScreen.COMMAND) }
 
     val currentClient = client
-    if (currentClient != null) {
-        CommandScreen(
+    if (currentClient == null) {
+        ScanScreen(manager = manager)
+        return
+    }
+
+    when (screen) {
+        ConnectedScreen.COMMAND -> CommandScreen(
             manager = manager,
             client = currentClient,
+            onOpenImageScreen = { screen = ConnectedScreen.IMAGE },
         )
-    } else {
-        ScanScreen(manager = manager)
+
+        ConnectedScreen.IMAGE -> ImageScreen(
+            client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
     }
 }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/ImageScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/ImageScreen.kt
@@ -1,0 +1,157 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.graphics.BitmapFactory
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import app.jigglass.glass.GlassClient
+
+private const val TAG = "ImageScreen"
+
+/** 画像をグラスの画像表示ページに送る画面。技適マークの表示に使われているのと同じ画面 */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImageScreen(client: GlassClient, onBack: () -> Unit) {
+    val context = LocalContext.current
+    val commandManager = remember(client) { client.createCommandManager() }
+
+    var image by remember { mutableStateOf<GrayscaleImage?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        try {
+            val bitmap = context.contentResolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it)
+            }
+            if (bitmap == null) {
+                error = "画像を読み込めませんでした"
+                return@rememberLauncherForActivityResult
+            }
+            image = bitmap.toGlassGrayscale()
+        } catch (e: Throwable) {
+            Log.e(TAG, "failed to load image", e)
+            error = e.message
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("画像を送る") }) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                "グラスに送れるのは ${GLASS_IMAGE_MAX_SIZE}x$GLASS_IMAGE_MAX_SIZE まで。" +
+                    "選んだ画像は縦横比を保って縮小し、輝度だけを送る。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    picker.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("画像を選ぶ")
+            }
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = { image = testPatternImage() },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("テストパターンを使う")
+            }
+
+            val current = image
+            if (current != null) {
+                Spacer(Modifier.height(24.dp))
+                Image(
+                    bitmap = remember(current) { current.toBitmap().asImageBitmap() },
+                    contentDescription = "グラスに送る画像のプレビュー",
+                    modifier = Modifier.size(196.dp),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "${current.width}x${current.height} / ${current.pixels.size} bytes",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                Spacer(Modifier.height(16.dp))
+                Button(
+                    onClick = {
+                        Log.d(TAG, "sendImage: ${current.width}x${current.height}")
+                        try {
+                            commandManager.enterImageDisplayPage()
+                            commandManager.sendImage(
+                                width = current.width,
+                                height = current.height,
+                                grayscale = current.pixels,
+                            )
+                        } catch (e: Throwable) {
+                            Log.e(TAG, "sendImage failed", e)
+                            error = e.message
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("グラスに送る")
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+            OutlinedButton(
+                onClick = {
+                    commandManager.enterHomePage()
+                    onBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("戻る（グラスは Home へ）")
+            }
+
+            error?.let { message ->
+                Spacer(Modifier.height(16.dp))
+                Text(message, color = MaterialTheme.colorScheme.error)
+                TextButton(onClick = { error = null }) {
+                    Text("エラーを消す")
+                }
+            }
+        }
+    }
+}

--- a/samples/kmp/snippets/build.gradle.kts
+++ b/samples/kmp/snippets/build.gradle.kts
@@ -28,6 +28,6 @@ android {
 }
 
 dependencies {
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.11")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.0.12")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/ArgumentNames.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/ArgumentNames.kt
@@ -60,6 +60,38 @@ internal object ArgumentNames {
         commandManager.syncNotificationCount(count = 1)
         commandManager.sendMeeting(meetingType = 0x00, text = "text", percent = 0)
         commandManager.sendAiChatText(text = "text")
+        commandManager.sendTeleprompterContent(content = "content", percent = 0)
+        commandManager.sendTeleprompterLine(text = "text", percent = 0, scrollUp = false)
+        commandManager.sendTeleprompterTime(time = "01:23")
+        commandManager.sendEmptyScreenContent(content = "content")
+        commandManager.sendImage(width = 196, height = 196, grayscale = ByteArray(196 * 196))
+        commandManager.sendAiChatLanguage(languageCode = "JPN")
+        commandManager.sendWakeupTiltThreshold(degrees = 10)
+        commandManager.sendSettingPageVisibility(show = true)
+        commandManager.sendSetting(name = CommandManager.SettingKey.FONT_SIZE, value = 1)
+        commandManager.syncWeather(type = CommandManager.WeatherType.TEMPERATURE, value = 20)
+        commandManager.requestLog(type = CommandManager.GlassLogType.SYSLOG)
+        commandManager.sendTeleprompterStatus(
+            status = CommandManager.TeleprompterStatus.STARTED,
+            mode = CommandManager.TeleprompterMode.TELEPROMPT,
+        )
+        commandManager.sendEmptyScreenStatus(status = CommandManager.TeleprompterStatus.READY)
+        commandManager.sendAdjust(
+            status = CommandManager.AdjustStatus.SHOW,
+            imageType = CommandManager.AdjustImageType.HOME,
+        )
+        commandManager.sendAiChatSenderText(
+            sender = CommandManager.AiChatSender.AI,
+            text = "text",
+            model = CommandManager.AiChatModel.SABERA_AI,
+        )
+        commandManager.sendAiChatSenderStatus(
+            sender = CommandManager.AiChatSender.AI,
+            status = CommandManager.AiChatStatus.GENERATING,
+            model = CommandManager.AiChatModel.SABERA_AI,
+        )
+        commandManager.sendAiChatSender(sender = CommandManager.AiChatSender.USER)
+        commandManager.sendAiChatStatus(status = CommandManager.AiChatStatus.COMPLETE)
     }
 
     fun remoteControlListener(commandManager: CommandManager, listener: CommandManager.RemoteControlListener) {

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
@@ -98,6 +98,21 @@ internal object CommandSnippets {
         // #endsnippet
     }
 
+    fun imageDisplay(commandManager: CommandManager, grayscale: ByteArray) {
+        // #snippet CommandManager.sendImage
+        commandManager.enterImageDisplayPage()
+        // grayscale は1画素1バイト・左上から行優先。3bitへの量子化とRLE圧縮はSDKが行う
+        commandManager.sendImage(width = 196, height = 196, grayscale = grayscale)
+        // #endsnippet
+    }
+
+    fun enterImageDisplay(commandManager: CommandManager) {
+        // #snippet CommandManager.enterImageDisplayPage
+        // 技適マークの表示にも使っている画像表示ページ
+        commandManager.enterImageDisplayPage()
+        // #endsnippet
+    }
+
     fun remoteController(commandManager: CommandManager) {
         // #snippet CommandManager.addRemoteControllerEventListener
         val listener = object : CommandManager.RemoteControlListener {

--- a/scripts/gen-api-docs.py
+++ b/scripts/gen-api-docs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """docs/api 配下の API リファレンス雛形を生成する。
 
-シグネチャは SDK 0.0.11 の公開 API に合わせたもの。
+シグネチャは SDK 0.0.12 の公開 API に合わせたもの。
 SDK のバージョンを上げてメソッドが増減したら SPEC を更新して再実行する。
 
 既存ファイルは上書きしない（人間が書いた本文を守るため）。--force で上書き。
@@ -270,13 +270,14 @@ SPEC = [
               [("status", "CommandManager.TeleprompterStatus", "`READY` / `STARTED` / `PAUSED`")],
               summary="汎用テキスト表示ページの状態を送る。`READY` で空画面に戻る。",
               related=["enterEmptyScreenPage"]),
-            m("sendImage", "fun sendImage(width: Int, height: Int, encodedBitmap: ByteArray)",
+            m("sendImage", "fun sendImage(width: Int, height: Int, grayscale: ByteArray)",
               [("width", "Int", "画像の幅。196まで"),
                ("height", "Int", "画像の高さ。196まで"),
-               ("encodedBitmap", "ByteArray", "エンコード済みの画像データ")],
+               ("grayscale", "ByteArray",
+                "1画素1バイトのグレースケール。長さは `width * height` 以上")],
               summary="画像表示ページに画像を送る。enterImageDisplayPage で開いてから呼ぶ。"
-                      "ビットマップは3bitグレースケールをRLE圧縮したバイト列で、"
-                      "エンコードは呼び出し側で行う。"
+                      "渡すのはリサイズ済みのグレースケールで、1画素1バイト・左上から行優先の並び。"
+                      "輝度は 0-255 のままでよく、グラスが読む3bitへの量子化とRLE圧縮は SDK が行う。"
                       "グラス側のバッファは静的で、196x196 を超えるサイズはファーム側で弾かれ、"
                       "何も表示されない。",
               related=["enterImageDisplayPage"]),
@@ -490,7 +491,7 @@ def api_index():
         "",
         f"# {API_TITLE}",
         "",
-        "Sabera App SDK (Kotlin) の公開 API。バージョン 0.0.11 時点。",
+        "Sabera App SDK (Kotlin) の公開 API。バージョン 0.0.12 時点。",
         "",
         "| 型 | 説明 |",
         "|---|---|",


### PR DESCRIPTION
## 概要

- 画像表示ページを SDK から実際に使えるようにする。KMP サンプルに画像を送る画面を足し、コード例とドキュメントも埋める
- これまでは利用側が3bitグレースケールへの量子化と RLE 圧縮を自分で実装しないと画像を表示できなかった。0.0.12 の `sendImage` はリサイズ済みのグレースケールを受け取り、圧縮は SDK が行う
- サンプルの依存とドキュメントの記述を 0.0.12 にそろえる

画像表示ページは技適マークの表示に使われているのと同じ画面。

## 変更点

サンプル

- 画像を送る画面を追加。端末の画像を選ぶ経路と、画像を用意しなくても試せるテストパターンの両方を置いた
- 送る前のプレビューと、実際に送るサイズ・バイト数を画面に出す
- コマンド画面から遷移できるようにした

SDK 追従

- `sendImage(width, height, grayscale)` — 引数がエンコード済みデータからグレースケールに変わった。1画素1バイト・左上から行優先で、輝度は 0-255 のまま渡せる
- サンプル（KMP app / snippets / Flutter android）の依存を 0.0.12 に更新

ドキュメント

- `sendImage` と `enterImageDisplayPage` のコード例を追加
- 引数名の検証（`ArgumentNames`）に新しいメソッドを追加。ドキュメントの引数名が実際の宣言とずれたらコンパイルで落ちる
- 参照している版の表記を 0.0.12 に更新

同じシグネチャのまま引数の意味が変わる破壊的変更のため、0.0.11 で `sendImage` を呼んでいるコードは渡す値を変える必要がある。

## 動作確認

- [x] サンプルの画像画面から端末の画像を選んで、グラスに表示される
- [x] テストパターンがグラスに表示される
- [x] 縦横比の違う画像でも歪まず、196x196 に収まるサイズに縮小されて送られる
- [x] 戻るとグラスが Home に戻る
- [x] サンプルが 0.0.12 を解決してビルドできる（KMP / Flutter の両方）
- [x] コード例の同期チェックとサンプルのコンパイル・ktlint が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)