### PR TITLE
👍️ マイク音声を24kHzにリサンプルするサンプルを追加する

### DIFF
--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/audio/PcmResampler.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/audio/PcmResampler.kt
@@ -1,0 +1,67 @@
+package jp.jig.glasses.sample.kmp.audio
+
+import kotlin.math.floor
+
+/**
+ * PCM16 リトルエンディアン・モノラルのサンプルレート変換。
+ * グラスのマイクは 16kHz で流れてくるが、リアルタイム音声 API は 24kHz を要求することが多い。
+ *
+ * 直線補間で、チャンクをまたぐ位置と直前のサンプルを持ち越す。
+ * 1チャンクごとに作り直すと継ぎ目でプツプツ鳴るので、ストリーム1本につき1インスタンスを使い回す。
+ * スレッドセーフではない。
+ */
+class PcmResampler(
+    private val inputRate: Int,
+    private val outputRate: Int,
+) {
+    /** 出力1サンプルぶんの、入力サンプル単位での進み幅 */
+    private val step = inputRate.toDouble() / outputRate.toDouble()
+
+    /** 次に出力したい位置。今回のチャンクの先頭を 0 とした入力サンプル単位 */
+    private var position = 0.0
+
+    /** 前のチャンクの末尾サンプル。position が負のとき補間の左端に使う */
+    private var previous: Short = 0
+
+    fun reset() {
+        position = 0.0
+        previous = 0
+    }
+
+    fun resample(pcm: ByteArray): ByteArray {
+        if (inputRate == outputRate) return pcm
+        val inputCount = pcm.size / 2
+        if (inputCount == 0) return ByteArray(0)
+
+        fun sampleAt(index: Int): Short =
+            if (index < 0) previous else pcm.readSample(index)
+
+        val output = ArrayList<Short>(((inputCount / step) + 2).toInt())
+        while (position < inputCount - 1) {
+            val index = floor(position).toInt()
+            val fraction = position - index
+            val left = sampleAt(index).toDouble()
+            val right = sampleAt(index + 1).toDouble()
+            output.add((left + (right - left) * fraction).toInt().toShort())
+            position += step
+        }
+
+        previous = pcm.readSample(inputCount - 1)
+        position -= inputCount
+
+        val bytes = ByteArray(output.size * 2)
+        output.forEachIndexed { i, sample -> bytes.writeSample(i, sample) }
+        return bytes
+    }
+}
+
+private fun ByteArray.readSample(index: Int): Short {
+    val offset = index * 2
+    return (((this[offset + 1].toInt() shl 8) or (this[offset].toInt() and 0xFF)).toShort())
+}
+
+private fun ByteArray.writeSample(index: Int, sample: Short) {
+    val offset = index * 2
+    this[offset] = (sample.toInt() and 0xFF).toByte()
+    this[offset + 1] = ((sample.toInt() shr 8) and 0xFF).toByte()
+}

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/MicScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/MicScreen.kt
@@ -31,14 +31,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.jigglass.glass.GlassClient
+import jp.jig.glasses.sample.kmp.audio.PcmResampler
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.math.sqrt
 
 private const val TAG = "MicScreen"
 
+/** グラスのマイクのサンプルレート */
+private const val INPUT_SAMPLE_RATE = 16_000
+
+/** リアルタイム音声 API に多い 24kHz。リサンプルの出力レート */
+private const val OUTPUT_SAMPLE_RATE = 24_000
+
 /** PCM16 モノラル 16kHz。1秒ぶんのバイト数 */
-private const val BYTES_PER_SECOND = 16_000 * 2
+private const val BYTES_PER_SECOND = INPUT_SAMPLE_RATE * 2
 
 /** 16bit の最大値。レベルの正規化に使う */
 private const val PCM_FULL_SCALE = 32_768f
@@ -61,13 +68,18 @@ fun MicScreen(client: GlassClient, onBack: () -> Unit) {
     var level by remember { mutableStateOf(0f) }
     var peak by remember { mutableStateOf(0f) }
     var elapsedMs by remember { mutableStateOf(0L) }
+    var resampledBytes by remember { mutableStateOf(0L) }
     var error by remember { mutableStateOf<String?>(null) }
 
     var startedAtMs by remember { mutableStateOf(0L) }
 
+    val resampler = remember { PcmResampler(INPUT_SAMPLE_RATE, OUTPUT_SAMPLE_RATE) }
+
     DisposableEffect(commandManager) {
         val job: Job = scope.launch {
             commandManager.micAudio.collect { pcm ->
+                // 24kHz を要求する送り先にはここで変換した PCM を渡す
+                resampledBytes += resampler.resample(pcm).size
                 totalBytes += pcm.size
                 chunkCount += 1
                 lastChunkBytes = pcm.size
@@ -125,10 +137,20 @@ fun MicScreen(client: GlassClient, onBack: () -> Unit) {
                 style = MaterialTheme.typography.bodySmall,
             )
 
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            Text("${OUTPUT_SAMPLE_RATE / 1000}kHz に変換して $resampledBytes バイト")
+            Text(
+                "16kHz のままリアルタイム音声 API に送ると速度とピッチがずれる",
+                style = MaterialTheme.typography.bodySmall,
+            )
+
             Spacer(Modifier.height(24.dp))
             Button(
                 onClick = {
                     totalBytes = 0
+                    resampledBytes = 0
+                    resampler.reset()
                     chunkCount = 0
                     peak = 0f
                     startedAtMs = System.currentTimeMillis()


### PR DESCRIPTION
## 概要

- グラスのマイク音声は 16kHz 固定だが、リアルタイム音声 API は 24kHz を要求するものが多い。そのまま送ると速度とピッチがずれるため、サンプル側にサンプルレートを変換する手段を用意する
- チャンクをまたいでも継ぎ目が鳴らないよう、変換の状態はストリーム単位で持ち回す
- KMP サンプルのマイク画面で、変換後のバイト数が見えるようにする

## 動作確認

- [ ] マイク画面で受信を始めると、変換後のバイト数が受信バイト数の 1.5 倍で増えていく
- [ ] 受信を始め直しても、変換後のカウントが 0 に戻る
- [ ] `./gradlew :app:compileDebugKotlin ktlintCheck` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)