### PR TITLE
feat(flutter-sample): add song search and saved-tracks map, fix build

### DIFF
--- a/samples/flutter/analysis_options.yaml
+++ b/samples/flutter/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/samples/flutter/android/app/src/main/kotlin/jp/jig/glasses/sample/flutter/glasses_sdk_flutter_sample/GlassesSdkPlugin.kt
+++ b/samples/flutter/android/app/src/main/kotlin/jp/jig/glasses/sample/flutter/glasses_sdk_flutter_sample/GlassesSdkPlugin.kt
@@ -154,7 +154,7 @@ class GlassesSdkPlugin(private val activity: Activity) :
             }
             "sendAIContent" -> {
                 val content = call.argument<String>("content") ?: ""
-                runCommand(result) { it.sendAIContent(content) }
+                runCommand(result) { it.sendAiChatText(content) }
             }
             "sendTranslateContent" -> {
                 val content = call.argument<String>("content") ?: ""

--- a/samples/flutter/android/gradle.properties
+++ b/samples/flutter/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/samples/flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/samples/flutter/android/settings.gradle.kts
+++ b/samples/flutter/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.10" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")

--- a/samples/flutter/lib/main.dart
+++ b/samples/flutter/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'command_page.dart';
+import 'music_search_page.dart';
+import 'saved_tracks_map_page.dart';
 import 'scan_page.dart';
 import 'src/glasses_sdk.dart';
 
@@ -32,9 +34,11 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  int _tabIndex = 0;
+
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<GlassConnectionState>(
+    final glassesTab = StreamBuilder<GlassConnectionState>(
       stream: GlassesSdk.instance.connectionState,
       initialData: GlassConnectionState.disconnected,
       builder: (context, snapshot) {
@@ -44,6 +48,21 @@ class _HomePageState extends State<HomePage> {
         }
         return const ScanPage();
       },
+    );
+
+    final pages = [glassesTab, const MusicSearchPage(), SavedTracksMapPage()];
+
+    return Scaffold(
+      body: pages[_tabIndex],
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _tabIndex,
+        onDestinationSelected: (index) => setState(() => _tabIndex = index),
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.bluetooth), label: 'Glasses'),
+          NavigationDestination(icon: Icon(Icons.music_note), label: '楽曲検索'),
+          NavigationDestination(icon: Icon(Icons.map), label: '保存した曲'),
+        ],
+      ),
     );
   }
 }

--- a/samples/flutter/lib/music_search_page.dart
+++ b/samples/flutter/lib/music_search_page.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'src/music/itunes_search_service.dart';
+import 'src/music/itunes_track.dart';
+
+class MusicSearchPage extends StatefulWidget {
+  const MusicSearchPage({super.key});
+
+  @override
+  State<MusicSearchPage> createState() => _MusicSearchPageState();
+}
+
+class _MusicSearchPageState extends State<MusicSearchPage> {
+  final _service = ItunesSearchService();
+  final _queryCtrl = TextEditingController();
+
+  List<ItunesTrack> _tracks = const [];
+  bool _loading = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _queryCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _search() async {
+    final term = _queryCtrl.text;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final tracks = await _service.search(term);
+      if (!mounted) return;
+      setState(() => _tracks = tracks);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _openTrack(ItunesTrack track) async {
+    final uri = Uri.tryParse(track.trackViewUrl);
+    if (uri == null) return;
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && mounted) {
+      setState(() => _error = 'URL を開けませんでした: ${track.trackViewUrl}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('楽曲検索')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _queryCtrl,
+              decoration: const InputDecoration(
+                labelText: '曲名・アーティスト名で検索',
+                border: OutlineInputBorder(),
+                suffixIcon: Icon(Icons.search),
+              ),
+              textInputAction: TextInputAction.search,
+              onSubmitted: (_) => _search(),
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+          Expanded(
+            child: _tracks.isEmpty
+                ? Center(
+                    child: Text(
+                      _loading ? '検索中...' : '曲名を入力して検索してください',
+                      style: TextStyle(color: Theme.of(context).hintColor),
+                    ),
+                  )
+                : ListView.separated(
+                    itemCount: _tracks.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final track = _tracks[index];
+                      return _TrackRow(
+                        track: track,
+                        onTap: () => _openTrack(track),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrackRow extends StatelessWidget {
+  final ItunesTrack track;
+  final VoidCallback onTap;
+
+  const _TrackRow({required this.track, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: onTap,
+      leading: _JacketWithPin(track: track, onTapPin: onTap),
+      title: Text(track.trackName, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(track.artistName, maxLines: 1, overflow: TextOverflow.ellipsis),
+      trailing: const Icon(Icons.chevron_right),
+    );
+  }
+}
+
+/// Album jacket thumbnail with a pin-shaped play button pinned to its
+/// bottom-right corner. Tapping the pin (or the jacket itself) jumps to the
+/// track's streaming/listen URL.
+class _JacketWithPin extends StatelessWidget {
+  final ItunesTrack track;
+  final VoidCallback onTapPin;
+
+  const _JacketWithPin({required this.track, required this.onTapPin});
+
+  @override
+  Widget build(BuildContext context) {
+    final artwork = track.artworkUrl512 ?? track.artworkUrl100;
+
+    return SizedBox(
+      width: 56,
+      height: 64,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: artwork == null
+                ? Container(
+                    width: 56,
+                    height: 56,
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    child: const Icon(Icons.music_note),
+                  )
+                : Image.network(
+                    artwork,
+                    width: 56,
+                    height: 56,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => Container(
+                      width: 56,
+                      height: 56,
+                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                      child: const Icon(Icons.music_note),
+                    ),
+                  ),
+          ),
+          Positioned(
+            right: -8,
+            bottom: -10,
+            child: _PlayPin(onTap: onTapPin),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A map-pin shaped play button, e.g. `location_on` with a play glyph
+/// inside the pin's head.
+class _PlayPin extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _PlayPin({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: 24,
+        height: 28,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Icon(Icons.location_on, size: 28, color: color),
+            const Positioned(
+              top: 3,
+              child: Icon(Icons.play_arrow, size: 12, color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/samples/flutter/lib/saved_tracks_map_page.dart
+++ b/samples/flutter/lib/saved_tracks_map_page.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'src/saved_tracks/saved_track.dart';
+import 'src/saved_tracks/saved_tracks_repository.dart';
+
+enum _ViewMode { map, list }
+
+/// "保存した曲" screen: map view with one pin per saved track, or a plain
+/// list view. Ported from the saved_tracks_map_apple.html mock.
+///
+/// Data (tracks, and later real map/geo + song-info-API fields on
+/// [SavedTrack]) comes from [repository] — swap in a real implementation
+/// once that's ready; this widget only depends on [SavedTracksRepository].
+class SavedTracksMapPage extends StatefulWidget {
+  final SavedTracksRepository repository;
+
+  SavedTracksMapPage({super.key, SavedTracksRepository? repository})
+      : repository = repository ?? MockSavedTracksRepository();
+
+  @override
+  State<SavedTracksMapPage> createState() => _SavedTracksMapPageState();
+}
+
+class _SavedTracksMapPageState extends State<SavedTracksMapPage> {
+  _ViewMode _view = _ViewMode.map;
+  List<SavedTrack> _tracks = const [];
+  bool _loading = true;
+  String? _selectedId;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final tracks = await widget.repository.fetchSavedTracks();
+    if (!mounted) return;
+    setState(() {
+      _tracks = tracks;
+      _loading = false;
+    });
+  }
+
+  Future<void> _removeSelected() async {
+    final id = _selectedId;
+    if (id == null) return;
+    await widget.repository.removeTrack(id);
+    if (!mounted) return;
+    setState(() {
+      _tracks = _tracks.where((t) => t.id != id).toList();
+      _selectedId = null;
+    });
+  }
+
+  int get _areaCount => _tracks.map((t) => t.area).toSet().length;
+
+  Future<void> _openListenUrl(SavedTrack track) async {
+    final url = track.listenUrl;
+    if (url == null) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('URL を開けませんでした')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _Header(view: _view, onChanged: (v) => setState(() => _view = v)),
+                    const SizedBox(height: 14),
+                    _StatsRow(count: _tracks.length, areaCount: _areaCount),
+                    const SizedBox(height: 14),
+                    Expanded(
+                      child: _view == _ViewMode.map
+                          ? _MapView(
+                              tracks: _tracks,
+                              selectedId: _selectedId,
+                              onSelect: (id) => setState(
+                                () => _selectedId = (_selectedId == id) ? null : id,
+                              ),
+                              onOpenListenUrl: _openListenUrl,
+                              onRemoveSelected: _removeSelected,
+                            )
+                          : _ListView(tracks: _tracks),
+                    ),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final _ViewMode view;
+  final ValueChanged<_ViewMode> onChanged;
+
+  const _Header({required this.view, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        const Text('保存した曲',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
+        SegmentedButton<_ViewMode>(
+          segments: const [
+            ButtonSegment(value: _ViewMode.map, label: Text('マップ')),
+            ButtonSegment(value: _ViewMode.list, label: Text('一覧')),
+          ],
+          selected: {view},
+          onSelectionChanged: (s) => onChanged(s.first),
+          showSelectedIcon: false,
+        ),
+      ],
+    );
+  }
+}
+
+class _StatsRow extends StatelessWidget {
+  final int count;
+  final int areaCount;
+
+  const _StatsRow({required this.count, required this.areaCount});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(child: _StatCard(label: '保存曲数', value: '$count')),
+        const SizedBox(width: 10),
+        Expanded(child: _StatCard(label: 'エリア数', value: '$areaCount')),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _StatCard({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label,
+                style: TextStyle(fontSize: 12, color: Theme.of(context).hintColor)),
+            const SizedBox(height: 3),
+            Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MapView extends StatelessWidget {
+  final List<SavedTrack> tracks;
+  final String? selectedId;
+  final ValueChanged<String> onSelect;
+  final ValueChanged<SavedTrack> onOpenListenUrl;
+  final VoidCallback onRemoveSelected;
+
+  const _MapView({
+    required this.tracks,
+    required this.selectedId,
+    required this.onSelect,
+    required this.onOpenListenUrl,
+    required this.onRemoveSelected,
+  });
+
+  SavedTrack? get _selected {
+    for (final track in tracks) {
+      if (track.id == selectedId) return track;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          flex: 3,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              color: const Color(0xFFE3E7EA),
+              // TODO: replace with a real map widget (e.g. google_maps_flutter)
+              // once [SavedTrack] carries real lat/lng instead of mock
+              // percentage coordinates.
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      for (final track in tracks)
+                        Positioned(
+                          left: constraints.maxWidth * track.mapX / 100 -
+                              _MapPin.size / 2,
+                          top: constraints.maxHeight * track.mapY / 100 -
+                              _MapPin.size / 2,
+                          child: _MapPin(
+                            track: track,
+                            selected: track.id == selectedId,
+                            onTap: () {
+                              onSelect(track.id);
+                              onOpenListenUrl(track);
+                            },
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+        if (_selected != null) ...[
+          const SizedBox(height: 12),
+          _SelectedTrackSheet(track: _selected!, onRemove: onRemoveSelected),
+        ],
+      ],
+    );
+  }
+}
+
+/// A map pin rendered as the track's small jacket photo. Tapping it jumps
+/// to the track's listen URL (see [_SavedTracksMapPageState._openListenUrl]).
+class _MapPin extends StatelessWidget {
+  static const double size = 40;
+
+  final SavedTrack track;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _MapPin({required this.track, required this.selected, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = selected ? const Color(0xFF007AFF) : const Color(0xFFFF3B30);
+    final artwork = track.artworkUrl;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: borderColor, width: 2.5),
+          boxShadow: const [
+            BoxShadow(color: Color(0x40000000), blurRadius: 3, offset: Offset(0, 1)),
+          ],
+        ),
+        child: ClipOval(
+          child: artwork == null
+              ? Container(
+                  color: const Color(0xFFE3E7EA),
+                  child: const Icon(Icons.music_note, size: 18),
+                )
+              : Image.network(
+                  artwork,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Container(
+                    color: const Color(0xFFE3E7EA),
+                    child: const Icon(Icons.music_note, size: 18),
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectedTrackSheet extends StatelessWidget {
+  final SavedTrack track;
+  final VoidCallback onRemove;
+
+  const _SelectedTrackSheet({required this.track, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(track.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${track.artist}　${track.area}　${track.savedAtLabel}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(fontSize: 13, color: Theme.of(context).hintColor),
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: onRemove,
+              icon: const Icon(Icons.delete_outline, color: Color(0xFFFF3B30)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ListView extends StatelessWidget {
+  final List<SavedTrack> tracks;
+
+  const _ListView({required this.tracks});
+
+  @override
+  Widget build(BuildContext context) {
+    if (tracks.isEmpty) {
+      return Center(
+        child: Text(
+          'まだ何も保存されていません。\n曲を判定すると、ここに記録されます。',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: Theme.of(context).hintColor),
+        ),
+      );
+    }
+    return Card(
+      margin: EdgeInsets.zero,
+      clipBehavior: Clip.antiAlias,
+      child: ListView.separated(
+        itemCount: tracks.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final track = tracks[index];
+          return ListTile(
+            leading: const CircleAvatar(
+              backgroundColor: Color(0xFFFF3B30),
+              foregroundColor: Colors.white,
+              child: Icon(Icons.music_note, size: 16),
+            ),
+            title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+            subtitle: Text(
+              '${track.artist}　${track.area}　${track.savedAtLabel}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/samples/flutter/lib/src/music/itunes_search_service.dart
+++ b/samples/flutter/lib/src/music/itunes_search_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'itunes_track.dart';
+
+/// Searches songs via the public iTunes Search API (no auth required).
+/// https://performance-partners.apple.com/search-api
+class ItunesSearchService {
+  static const _endpoint = 'https://itunes.apple.com/search';
+
+  Future<List<ItunesTrack>> search(String term, {int limit = 25}) async {
+    final trimmed = term.trim();
+    if (trimmed.isEmpty) return const [];
+
+    final uri = Uri.parse(_endpoint).replace(queryParameters: {
+      'term': trimmed,
+      'media': 'music',
+      'entity': 'song',
+      'limit': '$limit',
+    });
+
+    final response = await http.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('iTunes Search API error: HTTP ${response.statusCode}');
+    }
+
+    final body = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    final results = (body['results'] as List<dynamic>? ?? const [])
+        .cast<Map<String, dynamic>>();
+
+    return results.map(ItunesTrack.fromJson).toList();
+  }
+}

--- a/samples/flutter/lib/src/music/itunes_track.dart
+++ b/samples/flutter/lib/src/music/itunes_track.dart
@@ -1,0 +1,39 @@
+/// A single song result from the iTunes Search API.
+class ItunesTrack {
+  final int trackId;
+  final String trackName;
+  final String artistName;
+
+  /// Small artwork thumbnail (100x100) returned by the API.
+  final String? artworkUrl100;
+
+  /// 30 second AAC preview of the track, when available.
+  final String? previewUrl;
+
+  /// Apple Music / iTunes page for the track — used to open the full song.
+  final String trackViewUrl;
+
+  const ItunesTrack({
+    required this.trackId,
+    required this.trackName,
+    required this.artistName,
+    required this.artworkUrl100,
+    required this.previewUrl,
+    required this.trackViewUrl,
+  });
+
+  /// Higher resolution artwork, derived from the 100x100 thumbnail URL.
+  String? get artworkUrl512 =>
+      artworkUrl100?.replaceFirst('100x100bb', '512x512bb');
+
+  factory ItunesTrack.fromJson(Map<String, dynamic> json) {
+    return ItunesTrack(
+      trackId: json['trackId'] as int,
+      trackName: json['trackName'] as String? ?? 'Unknown Track',
+      artistName: json['artistName'] as String? ?? 'Unknown Artist',
+      artworkUrl100: json['artworkUrl100'] as String?,
+      previewUrl: json['previewUrl'] as String?,
+      trackViewUrl: json['trackViewUrl'] as String? ?? '',
+    );
+  }
+}

--- a/samples/flutter/lib/src/saved_tracks/saved_track.dart
+++ b/samples/flutter/lib/src/saved_tracks/saved_track.dart
@@ -1,0 +1,37 @@
+/// A song the user saved (e.g. after an on-glasses song identification),
+/// optionally tied to where/when it was heard.
+///
+/// [mapX]/[mapY] are placeholder coordinates (0-100, percentage position on
+/// the mock map canvas) until real geolocation + map rendering is wired up.
+class SavedTrack {
+  final String id;
+  final String title;
+  final String artist;
+
+  /// Human-readable area label (e.g. "渋谷"). Will later be derived from a
+  /// real lat/lng once location data is linked in.
+  final String area;
+
+  /// Display label for when the track was saved (e.g. "8/12 19:40").
+  final String savedAtLabel;
+
+  final double mapX;
+  final double mapY;
+
+  /// Jacket artwork / streaming link, filled in once the song-info API
+  /// (see MusicSearchPage's ItunesSearchService) is linked to saved tracks.
+  final String? artworkUrl;
+  final String? listenUrl;
+
+  const SavedTrack({
+    required this.id,
+    required this.title,
+    required this.artist,
+    required this.area,
+    required this.savedAtLabel,
+    required this.mapX,
+    required this.mapY,
+    this.artworkUrl,
+    this.listenUrl,
+  });
+}

--- a/samples/flutter/lib/src/saved_tracks/saved_tracks_repository.dart
+++ b/samples/flutter/lib/src/saved_tracks/saved_tracks_repository.dart
@@ -1,0 +1,92 @@
+import '../music/itunes_search_service.dart';
+import 'saved_track.dart';
+
+/// Source of the user's saved tracks. [MockSavedTracksRepository] below is
+/// the only implementation for now; once the song-identification API and
+/// location data are ready, add e.g. an `ApiSavedTracksRepository` that
+/// implements this same interface and swap it in in `main.dart` /
+/// `SavedTracksMapPage` — the UI does not need to change.
+abstract class SavedTracksRepository {
+  Future<List<SavedTrack>> fetchSavedTracks();
+
+  Future<void> removeTrack(String id);
+}
+
+class MockSavedTracksRepository implements SavedTracksRepository {
+  final ItunesSearchService _musicLookup = ItunesSearchService();
+
+  static final List<SavedTrack> _seeds = [
+    const SavedTrack(
+      id: '1',
+      title: '丸ノ内サディスティック',
+      artist: '椎名林檎',
+      area: '渋谷',
+      savedAtLabel: '8/12 19:40',
+      mapX: 40,
+      mapY: 42,
+    ),
+    const SavedTrack(
+      id: '2',
+      title: 'Pretender',
+      artist: 'Official髭男dism',
+      area: '新宿',
+      savedAtLabel: '8/14 08:05',
+      mapX: 68,
+      mapY: 66,
+    ),
+    const SavedTrack(
+      id: '3',
+      title: '夜に駆ける',
+      artist: 'YOASOBI',
+      area: '池袋',
+      savedAtLabel: '8/16 21:12',
+      mapX: 22,
+      mapY: 74,
+    ),
+    const SavedTrack(
+      id: '4',
+      title: 'Lemon',
+      artist: '米津玄師',
+      area: '渋谷',
+      savedAtLabel: '8/18 12:30',
+      mapX: 48,
+      mapY: 30,
+    ),
+  ];
+
+  List<SavedTrack>? _tracks;
+
+  @override
+  Future<List<SavedTrack>> fetchSavedTracks() async {
+    _tracks ??= await Future.wait(_seeds.map(_withJacketAndListenUrl));
+    return List.unmodifiable(_tracks!);
+  }
+
+  /// Looks up the jacket image and listen URL for a saved track via the
+  /// iTunes Search API (title/area/time stay as saved; only song metadata
+  /// comes from the lookup).
+  Future<SavedTrack> _withJacketAndListenUrl(SavedTrack seed) async {
+    try {
+      final results = await _musicLookup.search('${seed.title} ${seed.artist}', limit: 1);
+      final match = results.isEmpty ? null : results.first;
+      return SavedTrack(
+        id: seed.id,
+        title: seed.title,
+        artist: seed.artist,
+        area: seed.area,
+        savedAtLabel: seed.savedAtLabel,
+        mapX: seed.mapX,
+        mapY: seed.mapY,
+        artworkUrl: match?.artworkUrl512 ?? match?.artworkUrl100,
+        listenUrl: match?.trackViewUrl,
+      );
+    } catch (_) {
+      return seed;
+    }
+  }
+
+  @override
+  Future<void> removeTrack(String id) async {
+    _tracks?.removeWhere((t) => t.id == id);
+  }
+}

--- a/samples/flutter/pubspec.lock
+++ b/samples/flutter/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,30 +75,51 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -111,26 +132,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.0"
   path:
     dependency: transitive
     description:
@@ -139,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -188,18 +217,90 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.12"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -208,6 +309,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/samples/flutter/pubspec.yaml
+++ b/samples/flutter/pubspec.yaml
@@ -35,6 +35,10 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  # Music search: querying iTunes Search API and opening the streaming URL.
+  http: ^1.2.2
+  url_launcher: ^6.3.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/samples/flutter/test/widget_test.dart
+++ b/samples/flutter/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:sabera_app_sdk_flutter_sample/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+  testWidgets('app builds and shows the bottom navigation tabs',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const GlassesSdkSampleApp());
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('楽曲検索'), findsOneWidget);
+    expect(find.text('保存した曲'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Add a music search screen (iTunes Search API): results show jacket art with a play-pin overlay that opens the track's listen URL.
- Add a saved-tracks screen (map + list view) behind a `SavedTracksRepository` interface, seeded with mock location/time data. Map pins render as the track's jacket photo (looked up via the same iTunes Search API) and tapping one opens the listen URL.
- Fix `GlassesSdkPlugin.kt`: `sabera-app-core` 0.6.0 renamed `CommandManager.sendAIContent` to `sendAiChatText`; the sample still called the old name and failed to compile.
- Bump Gradle/AGP/Kotlin (8.10.2/8.7.0/2.3.10 -> 9.3.1/9.1.0/2.4.0) to match this Flutter version's minimum supported Gradle plugin.

## Test plan
- [x] `flutter analyze` - no issues
- [x] `flutter test` - all tests passed
- [x] `flutter build apk --debug` - succeeded
- [x] `flutter run` on a physical Pixel 9a - app launches, tabs render
