### PR TITLE
📝 ページごとの使い方ドキュメントを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Sabera App SDK の使い方を示すサンプルアプリ集。
 ## ドキュメント
 
 - [Getting Started](docs/getting-started.md) — SDK のセットアップと基本的な使い方
+- [ページごとの使い方](docs/pages/) — グラスの画面ごとに、開き方と送るもの
 - [API リファレンス](docs/api/) — 公開 API の一覧（内容は執筆中）
 - [ドキュメントの作り方](docs/authoring.md) — サイトの構成、コード例の検証、デプロイ
 

--- a/docs/api-history.md
+++ b/docs/api-history.md
@@ -1,6 +1,6 @@
 ---
 title: メソッドの追加履歴
-nav_order: 5
+nav_order: 6
 ---
 
 # メソッドの追加履歴

--- a/docs/api/command-manager/enter-translate-page.md
+++ b/docs/api/command-manager/enter-translate-page.md
@@ -24,7 +24,7 @@ fun enterTranslatePage()
 <!-- snippet: CommandManager.enterTranslatePage -->
 ```kotlin
 commandManager.enterTranslatePage()
-commandManager.sendTranslateLanguage(source = "en", target = "ja")
+commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
 commandManager.sendTranslateContent("これは訳文です")
 ```
 <!-- /snippet -->

--- a/docs/api/command-manager/send-translate-language.md
+++ b/docs/api/command-manager/send-translate-language.md
@@ -19,8 +19,8 @@ fun sendTranslateLanguage(source: String, target: String)
 
 | 名前 | 型 | 説明 |
 |---|---|---|
-| `source` | `String` | 翻訳元の言語コード。"en" など |
-| `target` | `String` | 翻訳先の言語コード。"ja" など |
+| `source` | `String` | 翻訳元の言語コード。`"ENG"` などの3文字 |
+| `target` | `String` | 翻訳先の言語コード。`"JPN"` などの3文字 |
 
 ## 戻り値
 
@@ -31,7 +31,7 @@ fun sendTranslateLanguage(source: String, target: String)
 <!-- snippet: CommandManager.sendTranslateLanguage -->
 ```kotlin
 commandManager.enterTranslatePage()
-commandManager.sendTranslateLanguage(source = "en", target = "ja")
+commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
 commandManager.sendTranslateContent("Hello")
 ```
 <!-- /snippet -->

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 ---
 title: API リファレンス
-nav_order: 4
+nav_order: 5
 has_children: true
 ---
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,6 +1,6 @@
 ---
 title: ドキュメントの作り方
-nav_order: 6
+nav_order: 7
 ---
 
 # ドキュメントの作り方
@@ -14,12 +14,13 @@ nav_order: 6
 | `docs/_config.yml` | Jekyll の設定 |
 | `docs/Gemfile` | Jekyll とテーマ（just-the-docs）の固定 |
 | `docs/index.md` / `getting-started.md` | トップと入門 |
+| `docs/pages/**` | グラスの画面ごとの使い方。手で書く |
 | `docs/api/**` | メソッドごとのページ。`scripts/gen-api-docs.py` が雛形を作る |
 | `docs/_sass/color_schemes/` | 配色。`sabera.scss` がライト、`sabera-dark.scss` がダーク |
 | `docs/_sass/custom/custom.scss` | 前後リンクと配色切り替えボタンの見た目 |
 | `docs/_includes/` | head / ヘッダ / フッタへの差し込み |
 | `scripts/gen-api-docs.py` | API ページの雛形を書き出す |
-| `scripts/sync-snippets.py` | コード例を Kotlin から `docs/api/**` へ写す |
+| `scripts/sync-snippets.py` | コード例を Kotlin から `docs/api/**` と `docs/pages/**` へ写す |
 | `samples/kmp/snippets/` | コード例の出処。コンパイルと ktlint を通る |
 
 公開は GitHub Pages。`main` への push で Actions がビルドしてデプロイする（[デプロイ](#デプロイ)）。
@@ -106,7 +107,7 @@ Markdown 側の貼り先は雛形が用意している。
 python3 scripts/sync-snippets.py
 ```
 
-マーカー間が ` ```kotlin ` ブロックに置き換わる。id が一致するスニペットが無いページは
+マーカー間が ` ```kotlin ` ブロックに置き換わる。写す先は `docs/api/**` と `docs/pages/**`。id が一致するスニペットが無いページは
 そのまま残る。1つのスニペットを複数ページに貼りたいときは、貼り先の id を揃える。
 
 Jekyll の `include` を使わずページに直接書き込んでいるのは、GitHub 上で `.md` を読んだときにも

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,7 +158,7 @@ commandManager.sendTeleprompterContent("Hello")
 | ------------------------------------------------------- | ---------------------------------- |
 | `sendTeleprompterContent(content: String)`              | テレプロンプターに表示する文字列   |
 | `sendTranslateContent(content: String)`                 | 翻訳ページに表示する文字列         |
-| `sendTranslateLanguage(source: String, target: String)` | 翻訳の言語ペア（例: `"en", "ja"`） |
+| `sendTranslateLanguage(source: String, target: String)` | 翻訳の言語ペア（例: `"ENG", "JPN"`） |
 | `sendAiChatText(text: String)`                          | AI チャットに表示する文字列        |
 
 ページを開いてからコンテンツを送る。送信先のページが開いていないと表示されない。

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ nav_order: 1
 
 - [Getting Started](getting-started.html) — セットアップと基本的な使い方
 - [GitHub PAT の作り方](github-pat.html) — SDK 取得に必要なトークンの発行手順
+- [ページごとの使い方](pages/) — グラスの画面ごとに、開き方と送るもの
 - [API リファレンス](api/) — 公開 API の一覧
 - [メソッドの追加履歴](api-history.html) — どのメソッドがどのバージョンから使えるか
 

--- a/docs/pages/adjust.md
+++ b/docs/pages/adjust.md
@@ -1,0 +1,57 @@
+---
+title: 調整・デバッグ
+parent: ページごとの使い方
+nav_order: 9
+---
+
+# 調整・デバッグ
+
+かけ心地の調整と、動作確認のための画面。
+
+## ヘッドアップ角度調整
+
+`enterGlassAngleAdjustmentPage()` で開く。顔を上げたときに画面を点ける閾値は
+`sendWakeupTiltThreshold()` で度数で送る。
+
+<!-- snippet: pages.angle-adjustment -->
+```kotlin
+commandManager.enterGlassAngleAdjustmentPage()
+commandManager.sendWakeupTiltThreshold(degrees = 20)
+```
+<!-- /snippet -->
+
+## 画面位置調整
+
+`sendAdjust()` は表示位置の目安になる画像を出す。ページを開くコマンドではなく、
+今の画面の上に重ねる。
+
+<!-- snippet: pages.adjust -->
+```kotlin
+commandManager.sendAdjust(
+    status = CommandManager.AdjustStatus.SHOW,
+    imageType = CommandManager.AdjustImageType.HOME,
+)
+commandManager.sendAdjust(
+    status = CommandManager.AdjustStatus.CLOSE,
+    imageType = CommandManager.AdjustImageType.HOME,
+)
+```
+<!-- /snippet -->
+
+| imageType | 用途 |
+|---|---|
+| `HOME` | ホーム画面向けの位置合わせ |
+| `NAVIGATE` | ナビ画面向け |
+| `TELEPROMPT` | テレプロンプター向け |
+
+## IMU・照度のデバッグ
+
+`enterImuDebugPage()` でセンサーの生の値を出す画面を開く。アプリ側で値を扱うなら
+`imuData` を購読する。
+
+## 関連 API
+
+- `enterGlassAngleAdjustmentPage()`
+- `sendWakeupTiltThreshold(degrees: Int)`
+- `sendAdjust(status: CommandManager.AdjustStatus, imageType: CommandManager.AdjustImageType)`
+- `enterImuDebugPage()`

--- a/docs/pages/ai-chat.md
+++ b/docs/pages/ai-chat.md
@@ -1,0 +1,68 @@
+---
+title: AI アシスタント
+parent: ページごとの使い方
+nav_order: 3
+---
+
+# AI アシスタント
+
+質問と回答を吹き出しで並べる画面。生成はアプリ側で行い、テキストと状態を送る。
+
+## 開く
+
+本文のフォントは言語で変わり、グラスは開いた時点のフォントを使う。そのため
+`sendAiChatLanguage()` を先に送ってから `enterAiChatPage()` を呼ぶ。言語コードは
+`"JPN"` / `"ENG"` / `"CHS"` / `"CHT"` などの3文字。
+
+## 吹き出しを送る
+
+`sendAiChatSenderText()` は主体と本文をまとめて送る。質問は `USER`、回答は `AI`。
+`AI` のときは `model` を渡すと生成モデル名が出る。
+
+回答を流し始める前に `sendAiChatSenderStatus()` で `AI` と `GENERATING` を送り、
+書き終わったら `sendAiChatStatus(COMPLETE)` を送る。`COMPLETE` を送るまでグラスは
+生成中の表示を続ける。
+
+<!-- snippet: pages.ai-chat -->
+```kotlin
+// フォントを先に確定させるため、開く前に言語を送る
+commandManager.sendAiChatLanguage("JPN")
+commandManager.enterAiChatPage()
+
+commandManager.sendAiChatSenderText(sender = CommandManager.AiChatSender.USER, text = question)
+commandManager.sendAiChatSenderStatus(
+    sender = CommandManager.AiChatSender.AI,
+    status = CommandManager.AiChatStatus.GENERATING,
+)
+commandManager.sendAiChatSenderText(sender = CommandManager.AiChatSender.AI, text = answer)
+commandManager.sendAiChatStatus(CommandManager.AiChatStatus.COMPLETE)
+```
+<!-- /snippet -->
+
+1パケットに収まらない長文は、続きを `sendAiChatText()` で流す。こちらは主体を指定しない
+ので、最初の吹き出しは `sendAiChatSenderText()` で作る。
+
+## 消す・やめる
+
+<!-- snippet: pages.ai-chat-clear -->
+```kotlin
+commandManager.clearAiChat()
+```
+<!-- /snippet -->
+
+`clearAiChat()` は FEATURE_VERSION 1.1.0 以降のファームが対象。未対応のファームは
+このコマンドを読み捨てて表示が残るため、`clearAiChatLegacy()` で改行を流し込んで
+見かけ上クリアする。
+
+ページを離れるときは `enterHomePage()`。
+
+## 関連 API
+
+- `sendAiChatLanguage(languageCode: String)`
+- `enterAiChatPage()`
+- `sendAiChatSenderText(sender: CommandManager.AiChatSender, text: String, model: CommandManager.AiChatModel?)`
+- `sendAiChatSenderStatus(sender: CommandManager.AiChatSender, status: CommandManager.AiChatStatus, model: CommandManager.AiChatModel?)`
+- `sendAiChatStatus(status: CommandManager.AiChatStatus)`
+- `sendAiChatText(text: String)`
+- `clearAiChat()`
+- `clearAiChatLegacy()`

--- a/docs/pages/canvas.md
+++ b/docs/pages/canvas.md
@@ -1,0 +1,79 @@
+---
+title: 自由配置キャンバス
+parent: ページごとの使い方
+nav_order: 7
+---
+
+# 自由配置キャンバス
+
+座標を指定してテキストと画像を置く画面。キャンバスは 576x360 で、左上が原点。
+FEATURE_VERSION 2.1.0 以上のファームが対象（画像は 2.2.0 以上）。
+
+## 開いて送る
+
+`sendCanvas()` か `sendCanvasImage()` を送るだけで画面が切り替わる。先にページを開く
+必要はない。
+
+<!-- snippet: pages.canvas -->
+```kotlin
+commandManager.sendCanvas(
+    listOf(
+        CommandManager.CanvasElement(id = 0, x = 16, y = 8, width = 240, height = 40, text = "見出し"),
+    ),
+)
+// 画像はテキストの背面に置かれる
+commandManager.sendCanvasImage(id = 0, x = 16, y = 84, width = 192, height = 192, grayscale = photo)
+// 他の要素を残して id 1 だけ足す
+commandManager.sendCanvasElements(
+    listOf(
+        CommandManager.CanvasElement(id = 1, x = 16, y = 300, width = 240, height = 40, text = "キャプション"),
+    ),
+)
+commandManager.closeCanvas()
+```
+<!-- /snippet -->
+
+`sendCanvas()` は今ある要素を全て消してから、渡した要素を並べる。今ある要素を残したまま
+一部だけ置き直すなら `sendCanvasElements()`。既にある id に送ると座標とサイズごと差し替わり、
+テキストを空にするとその id が消える。
+
+はみ出した矩形は端で切られ、キャンバスの外に出た要素は描かれない。テキストは矩形内で
+左揃えに折り返し、あふれた分は切られる。
+
+## 画像を置く
+
+`sendCanvasImage()` の `grayscale` は画像表示ページと同じ形式で、1画素1バイト・左上から
+行優先。量子化と圧縮は SDK が行う。同じ id に送ると座標ごと差し替わり、`removeCanvasImage()`
+で1枚だけ消せる。画像はテキスト要素の背面に描かれるので、キャプションを重ねられる。
+
+数百バイトずつに分けて送るため、大きい画像ほど表示までに時間がかかる。続けて呼んでも
+SDK が分割送信を直列化するので、送信が混ざることはない。
+
+## 制限
+
+| 対象 | 上限 |
+|---|---|
+| テキスト要素 | id 0..7 の8個 |
+| 画像 | id 0..7 の8枚 |
+| テキストの合計 | 190バイト程度（分割送信できない） |
+| 画像のバッファ | 置いてある画像の `width * height * 2` の合計 + 受信中の圧縮データが 380,000 バイトまで |
+
+192角なら5枚が目安。テキストが収まらないときは `sendCanvasElements()` で1要素ずつ送れば
+表示は積み上がる。
+
+画像バッファはナビの全体ルート画像と共有しているため、**ナビ表示中はキャンバスの画像は使えない**。
+
+## 消す・やめる
+
+`clearCanvas()` はキャンバスを開いたまま全ての要素を消す。置いた画像も一緒に消える。
+`closeCanvas()` は閉じてホームなどに戻り、表示していた要素は破棄される。リモコンの
+戻る操作やホームへの遷移でも閉じる。
+
+## 関連 API
+
+- `sendCanvas(elements: List<CommandManager.CanvasElement>)`
+- `sendCanvasElements(elements: List<CommandManager.CanvasElement>)`
+- `sendCanvasImage(id: Int, x: Int, y: Int, width: Int, height: Int, grayscale: ByteArray)`
+- `removeCanvasImage(id: Int)`
+- `clearCanvas()`
+- `closeCanvas()`

--- a/docs/pages/image.md
+++ b/docs/pages/image.md
@@ -1,0 +1,40 @@
+---
+title: 画像表示
+parent: ページごとの使い方
+nav_order: 5
+---
+
+# 画像表示
+
+1枚の画像を全画面で出す画面。技適マークの表示に使っている。
+
+## 開いて送る
+
+`enterImageDisplayPage()` で開き、`sendImage()` で画像を送る。
+
+<!-- snippet: pages.image-display -->
+```kotlin
+commandManager.enterImageDisplayPage()
+// 196x196 を超えるとファームが弾いて何も出ない
+commandManager.sendImage(width = 196, height = 196, grayscale = grayscale)
+```
+<!-- /snippet -->
+
+渡すのはリサイズ済みのグレースケール。1画素1バイトで、左上から行優先に並べる。輝度は
+0-255 のまま渡してよく、グラスが読む3bitへの量子化と RLE 圧縮は SDK が行う。
+
+グラス側のバッファは静的なので、**196x196 を超えるサイズはファームが弾いて何も表示されない**。
+渡す前にアプリ側で縮小しておく。
+
+## 使い分け
+
+| したいこと | 使うもの |
+|---|---|
+| 1枚を全画面で出す | このページ |
+| 複数枚を座標指定で並べる | [自由配置キャンバス](canvas.html) の `sendCanvasImage()` |
+| 地図を出す | [ナビ](navigation.html) の `sendNavi()` / `sendNaviLargeImage()` |
+
+## 関連 API
+
+- `enterImageDisplayPage()`
+- `sendImage(width: Int, height: Int, grayscale: ByteArray)`

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -1,0 +1,54 @@
+---
+title: ページごとの使い方
+nav_order: 4
+has_children: true
+---
+
+# ページごとの使い方
+
+グラスは画面（ページ）ごとに使えるコマンドが決まっている。ここではページ単位に、開き方・
+送るもの・後片付けをまとめる。接続は済んでいて `CommandManager` を作ってある前提で書く。
+接続の手順は [Getting Started](../getting-started.html) を参照。
+
+```kotlin
+val commandManager = client.createCommandManager()
+```
+
+## ページ一覧
+
+| ページ | 開き方 | 主に送るもの | 必要ファーム |
+|---|---|---|---|
+| [テレプロンプター](teleprompter.html) | `enterTeleprompterPage()` | 原稿・再生状態・経過時間 | — |
+| [翻訳](translate.html) | `enterTranslatePage()` | 言語ペア・訳文 | — |
+| [AI アシスタント](ai-chat.html) | `enterAiChatPage()` | 吹き出しの本文・生成状態 | — |
+| [汎用テキスト表示](text.html) | `enterEmptyScreenPage()` | 本文 | — |
+| [画像表示](image.html) | `enterImageDisplayPage()` | 196x196 までの画像 | — |
+| [分割レイアウト](layout.html) | `sendLayout()` | 分割と領域ごとのテキスト | 2.0.0 |
+| [自由配置キャンバス](canvas.html) | `sendCanvas()` | 座標指定のテキストと画像 | 2.1.0 / 画像は 2.2.0 |
+| [ナビ](navigation.html) | `enterNavigationPage()` | 案内情報・進行方向・地図画像 | — |
+| [調整・デバッグ](adjust.html) | `enterGlassAngleAdjustmentPage()` など | 傾き閾値・調整画像 | — |
+
+「必要ファーム」は FEATURE_VERSION。満たさないファームはコマンドを読み捨てるので、
+アプリ側からは送れたように見えて何も起こらない。
+
+## 共通の約束
+
+**開いてから送る。** ほとんどのページはコンテンツだけ送っても表示されない。例外は
+分割レイアウトとキャンバスで、こちらは送ると同時に画面が切り替わる。
+
+**送信は投げっぱなし。** 送信系は同期メソッドだが内部でキューに積むだけで、呼び出しスレッドは
+ブロックしない。グラス側が受け取れたかどうかは返ってこない。
+
+**未接続だと捨てられる。** 送る前に `CommandManager.connected` を見る。
+
+**やめるときはホームに戻す。** `enterHomePage()` で開いていたページを閉じ、表示内容も捨てる。
+
+<!-- snippet: pages.home -->
+```kotlin
+// 開いていたページを閉じて表示内容を捨てる
+commandManager.enterHomePage()
+```
+<!-- /snippet -->
+
+**1パケットの上限がある。** 原稿や本文のように分割送信に対応しているものは長文を渡してよいが、
+分割レイアウトとキャンバスのテキストは分割できず、合計190バイト程度で切られる。

--- a/docs/pages/layout.md
+++ b/docs/pages/layout.md
@@ -1,0 +1,61 @@
+---
+title: 分割レイアウト
+parent: ページごとの使い方
+nav_order: 6
+---
+
+# 分割レイアウト
+
+画面を等分して、領域ごとにテキストを出す画面。FEATURE_VERSION 2.0.0 以上のファームが対象。
+
+## 開いて送る
+
+`sendLayout()` を送るだけで画面が切り替わる。先にページを開く必要はない。モードを送ると
+レイアウトは作り直され、全領域のテキストが消えたうえで `texts` が反映される。
+
+<!-- snippet: pages.layout -->
+```kotlin
+// 開く操作は要らない。モードを送るとその場で切り替わる
+commandManager.sendLayout(
+    mode = CommandManager.LayoutMode.QUAD,
+    texts = mapOf(0 to "左上", 1 to "右上", 2 to "左下", 3 to "右下"),
+)
+// 分割はそのまま、右下だけ書き換える
+commandManager.sendLayoutTexts(mapOf(3 to "書き換え"))
+// 空文字でその領域を消す
+commandManager.sendLayoutTexts(mapOf(3 to ""))
+commandManager.closeLayout()
+```
+<!-- /snippet -->
+
+領域番号の意味は分割ごとに変わる。
+
+| mode | 領域番号 |
+|---|---|
+| `FULL` | 0=全画面 |
+| `TOP_BOTTOM` | 0=上、1=下 |
+| `LEFT_RIGHT` | 0=左、1=右 |
+| `QUAD` | 0=左上、1=右上、2=左下、3=右下 |
+
+渡さなかった領域は空のまま。テキストは領域内で折り返し、あふれた分は切られる。
+
+## 一部だけ書き換える
+
+`sendLayoutTexts()` は分割を保ったまま、指定した領域のテキストだけ差し替える。空文字を
+渡すとその領域が消える。レイアウトが閉じているときに呼ぶと、全画面1領域として開く。
+
+## やめる
+
+`closeLayout()` で閉じ、表示していたテキストは破棄される。リモコンの戻る操作や
+ホームへの遷移でも閉じる。
+
+## 制限
+
+分割して送れないコマンドなので、**テキストの合計は190バイト程度まで**。超えた分は届かない。
+それより多くの文字を出したいなら領域を分けるのではなく [テレプロンプター](teleprompter.html) を使う。
+
+## 関連 API
+
+- `sendLayout(mode: CommandManager.LayoutMode, texts: Map<Int, String>)`
+- `sendLayoutTexts(texts: Map<Int, String>)`
+- `closeLayout()`

--- a/docs/pages/navigation.md
+++ b/docs/pages/navigation.md
@@ -1,0 +1,68 @@
+---
+title: ナビ
+parent: ページごとの使い方
+nav_order: 8
+---
+
+# ナビ
+
+次の曲がり角・距離・到着時刻と地図を出す画面。経路の計算はアプリ側で行い、表示内容だけを送る。
+
+## 開いて送る
+
+`enterNavigationPage()` で開き、`sendNaviLanguage()` で言語を決め、`sendNaviStatus()` で
+状態を送ってから `sendNavi()` で案内を送る。
+
+<!-- snippet: pages.navigation -->
+```kotlin
+commandManager.enterNavigationPage()
+commandManager.sendNaviLanguage("JPN")
+commandManager.sendNaviStatus(CommandManager.NaviStatus.START)
+commandManager.sendNavi(
+    maneuverIcon = CommandManager.ManeuverIcon.TURN_LEFT,
+    instructionText = "交差点を左折",
+    distanceText = "300m",
+    estimatedArrivalText = "12:34",
+    timeAndDistanceText = "10分 / 1.2km",
+    bitmapWidth = 128,
+    bitmapHeight = 128,
+    grayscale = map,
+)
+// 方位のドリフト補正。案内中は数秒おきに送る
+commandManager.sendNaviCourse(courseDegrees)
+// 着いたら到着画面に切り替える
+commandManager.sendNaviStatus(CommandManager.NaviStatus.ARRIVED)
+```
+<!-- /snippet -->
+
+| status | 画面 |
+|---|---|
+| `READY` | 案内前の待機 |
+| `START` | 案内中。`sendNavi()` の内容が出るのはこの状態のときだけ |
+| `ARRIVED` | 到着 |
+
+`sendNavi()` の地図は省略できる。渡すときは `bitmapWidth` と `bitmapHeight` も必須で、
+どちらも255まで。全体ルートのように大きい画像は `sendNaviLargeImage()` で送る。こちらは
+[キャンバス](canvas.html)の画像とグラス側のバッファを共有している。
+
+言語コードは `"JPN"` / `"ENG"` などの3文字。到着時刻ラベルの切り替えに使われ、画面遷移や
+表示状態には影響しない。
+
+## 方位を送り続ける
+
+グラスは磁力計を持たず、方位を単体で保てない。案内中は数秒おきに `sendNaviCourse()` で
+端末の GPS 進行方向を送り、ジャイロのドリフトを補正する。北を0とした時計回りの度数で、
+0以上360未満。
+
+## やめる
+
+`enterHomePage()` で閉じる。
+
+## 関連 API
+
+- `enterNavigationPage()`
+- `sendNaviLanguage(languageCode: String)`
+- `sendNaviStatus(status: CommandManager.NaviStatus)`
+- `sendNavi(maneuverIcon: CommandManager.ManeuverIcon, instructionText: String, distanceText: String, estimatedArrivalText: String, timeAndDistanceText: String, bitmapWidth: Int?, bitmapHeight: Int?, grayscale: ByteArray?)`
+- `sendNaviLargeImage(width: Int, height: Int, grayscale: ByteArray)`
+- `sendNaviCourse(courseDegrees: Double)`

--- a/docs/pages/teleprompter.md
+++ b/docs/pages/teleprompter.md
@@ -1,0 +1,87 @@
+---
+title: テレプロンプター
+parent: ページごとの使い方
+nav_order: 1
+---
+
+# テレプロンプター
+
+原稿をグラスに出して、読み上げに合わせて流す画面。
+
+## 開く
+
+`enterTeleprompterPage()` を呼ぶ。開く前に送った原稿は表示されないので、必ず先に開く。
+
+## 原稿を出す
+
+全文を渡すなら `sendTeleprompterContent()`。200バイトを超える分は SDK が分割して送る。
+`percent` つきの overload はスクロールバーの位置も一緒に送る。
+
+<!-- snippet: pages.teleprompter -->
+```kotlin
+commandManager.enterTeleprompterPage()
+commandManager.sendTeleprompterStatus(
+    status = CommandManager.TeleprompterStatus.READY,
+    mode = CommandManager.TeleprompterMode.TELEPROMPT,
+)
+commandManager.sendTeleprompterContent("読み上げる原稿", percent = 0)
+```
+<!-- /snippet -->
+
+`sendTeleprompterStatus()` は再生状態と表示モードをまとめて送る。別パケットに分けると
+動作が安定しないため、片方だけ変えたいときも両方渡す。
+
+| status | 意味 |
+|---|---|
+| `READY` | 再生前 |
+| `STARTED` | 再生中 |
+| `PAUSED` | 一時停止 |
+
+| mode | 意味 |
+|---|---|
+| `TELEPROMPT` | 原稿の読み上げ |
+| `TRANSCRIPT` | 文字起こし |
+| `TRANSLATION` | 翻訳 |
+
+## 読み上げに合わせて流す
+
+文字起こしのように次の1行が決まっていく使い方では、全文を送り直さずに
+`sendTeleprompterLine()` で1行ずつ追記する。`percent` でスクロールバーを進め、
+`scrollUp = true` にすると1行上へ戻る。
+
+経過時間は `sendTeleprompterTime()` に `mm:ss` の5文字で渡す。短ければ先頭が0埋めされ、
+長ければ切り捨てられる。
+
+<!-- snippet: pages.teleprompter-play -->
+```kotlin
+commandManager.sendTeleprompterStatus(
+    status = CommandManager.TeleprompterStatus.STARTED,
+    mode = CommandManager.TeleprompterMode.TELEPROMPT,
+)
+lines.forEachIndexed { index, line ->
+    // 全文を送り直さず、読み上げた分だけ流す
+    commandManager.sendTeleprompterLine(
+        text = line,
+        percent = (index + 1) * 100 / lines.size,
+    )
+    commandManager.sendTeleprompterTime("00:%02d".format(index))
+}
+commandManager.clearInscriptionText()
+```
+<!-- /snippet -->
+
+## 消す・やめる
+
+`clearInscriptionText()` で表示中のテキストが消える。翻訳ページとグラス側のバッファを
+共有しているため、消去はどちらのページでも同じコマンドになる。
+
+ページを離れるときは `enterHomePage()`。
+
+## 関連 API
+
+- `enterTeleprompterPage()`
+- `sendTeleprompterContent(content: String, percent: Int)`
+- `sendTeleprompterLine(text: String, percent: Int, scrollUp: Boolean)`
+- `sendTeleprompterStatus(status: CommandManager.TeleprompterStatus, mode: CommandManager.TeleprompterMode)`
+- `sendTeleprompterTime(time: String)`
+- `clearInscriptionText()`

--- a/docs/pages/text.md
+++ b/docs/pages/text.md
@@ -1,0 +1,33 @@
+---
+title: 汎用テキスト表示
+parent: ページごとの使い方
+nav_order: 4
+---
+
+# 汎用テキスト表示
+
+決まった用途を持たないテキスト画面。専用ページのない情報を出したいときに使う。
+
+## 開いて送る
+
+`enterEmptyScreenPage()` で開き、`sendEmptyScreenContent()` で本文を送る。200バイトを
+超える分は SDK が分割して送る。送るたびに表示は置き換わる。
+
+<!-- snippet: pages.empty-screen -->
+```kotlin
+commandManager.enterEmptyScreenPage()
+commandManager.sendEmptyScreenContent("好きな文字列をそのまま出せる")
+```
+<!-- /snippet -->
+
+## やめる
+
+`enterHomePage()` で閉じる。
+
+文字を置く位置まで決めたいなら [分割レイアウト](layout.html) か
+[自由配置キャンバス](canvas.html) を使う。
+
+## 関連 API
+
+- `enterEmptyScreenPage()`
+- `sendEmptyScreenContent(content: String)`

--- a/docs/pages/translate.md
+++ b/docs/pages/translate.md
@@ -13,7 +13,7 @@ nav_order: 2
 `enterTranslatePage()` を呼ぶ。次に `sendTranslateLanguage()` で言語ラベルを決め、
 `sendTranslateContent()` で本文を送る、の順で使う。
 
-言語コードは `"en"` / `"ja"` のような2文字。ラベルの表示だけを切り替えるコマンドなので、
+言語コードは `"ENG"` / `"JPN"` などの3文字。ラベルの表示だけを切り替えるコマンドなので、
 画面遷移は起こらない。
 
 ## 訳文を送る
@@ -23,7 +23,7 @@ nav_order: 2
 <!-- snippet: pages.translate -->
 ```kotlin
 commandManager.enterTranslatePage()
-commandManager.sendTranslateLanguage(source = "en", target = "ja")
+commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
 sentences.forEach { sentence ->
     // 送るたび全文が置き換わる
     commandManager.sendTranslateContent(sentence)

--- a/docs/pages/translate.md
+++ b/docs/pages/translate.md
@@ -1,0 +1,46 @@
+---
+title: 翻訳
+parent: ページごとの使い方
+nav_order: 2
+---
+
+# 翻訳
+
+訳文と言語ペアを出す画面。翻訳そのものはアプリ側で行い、結果だけを送る。
+
+## 開く
+
+`enterTranslatePage()` を呼ぶ。次に `sendTranslateLanguage()` で言語ラベルを決め、
+`sendTranslateContent()` で本文を送る、の順で使う。
+
+言語コードは `"en"` / `"ja"` のような2文字。ラベルの表示だけを切り替えるコマンドなので、
+画面遷移は起こらない。
+
+## 訳文を送る
+
+送るたびに表示は置き換わる。長い本文は SDK が分割して送る。
+
+<!-- snippet: pages.translate -->
+```kotlin
+commandManager.enterTranslatePage()
+commandManager.sendTranslateLanguage(source = "en", target = "ja")
+sentences.forEach { sentence ->
+    // 送るたび全文が置き換わる
+    commandManager.sendTranslateContent(sentence)
+}
+commandManager.clearInscriptionText()
+```
+<!-- /snippet -->
+
+## 消す・やめる
+
+`clearInscriptionText()` で消える。テレプロンプターと同じバッファを使っている。
+
+ページを離れるときは `enterHomePage()`。
+
+## 関連 API
+
+- `enterTranslatePage()`
+- `sendTranslateLanguage(source: String, target: String)`
+- `sendTranslateContent(content: String)`
+- `clearInscriptionText()`

--- a/samples/flutter/lib/command_page.dart
+++ b/samples/flutter/lib/command_page.dart
@@ -19,8 +19,8 @@ class _CommandPageState extends State<CommandPage> {
   final _teleprompterCtrl = TextEditingController(text: 'Hello from Flutter');
   final _aiCtrl = TextEditingController(text: '質問内容をどうぞ');
   final _translateCtrl = TextEditingController(text: 'Translate this');
-  final _sourceLangCtrl = TextEditingController(text: 'en');
-  final _targetLangCtrl = TextEditingController(text: 'ja');
+  final _sourceLangCtrl = TextEditingController(text: 'ENG');
+  final _targetLangCtrl = TextEditingController(text: 'JPN');
 
   final _gestures = <String>[];
   StreamSubscription<GestureType>? _gestureSub;

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/ArgumentNames.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/ArgumentNames.kt
@@ -50,7 +50,7 @@ internal object ArgumentNames {
         commandManager.parseResponse(value = byteArrayOf(0x00))
         commandManager.sendTeleprompterContent(content = "content")
         commandManager.sendTranslateContent(content = "content")
-        commandManager.sendTranslateLanguage(source = "en", target = "ja")
+        commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
         commandManager.sendDebugPhoneName(phoneName = "Pixel")
         commandManager.sendMessage(name = "app", title = "title", time = 0L, text = "text")
         commandManager.syncNotificationCount(count = 1)

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
@@ -260,9 +260,6 @@ internal object CommandSnippets {
         // #endsnippet
     }
 
-    // sendAiChatSender / sendAiChatStatus / sendAiChatSenderText / sendAiChatSenderStatus は
-    // 引数の PacketCommandUtils.AiChatSender・AiChatStatus が SDK 内部の型で、外から参照できない。
-    // アプリから使えるのは以下の2つだけ。
     fun aiChat(commandManager: CommandManager) {
         // #snippet CommandManager.sendAiChatText
         commandManager.enterAiChatPage()

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/CommandSnippets.kt
@@ -52,7 +52,7 @@ internal object CommandSnippets {
     fun translatePage(commandManager: CommandManager) {
         // #snippet CommandManager.enterTranslatePage
         commandManager.enterTranslatePage()
-        commandManager.sendTranslateLanguage(source = "en", target = "ja")
+        commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
         commandManager.sendTranslateContent("これは訳文です")
         // #endsnippet
     }
@@ -222,7 +222,7 @@ internal object CommandSnippets {
     fun translate(commandManager: CommandManager) {
         // #snippet CommandManager.sendTranslateLanguage
         commandManager.enterTranslatePage()
-        commandManager.sendTranslateLanguage(source = "en", target = "ja")
+        commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
         commandManager.sendTranslateContent("Hello")
         // #endsnippet
     }

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/PageSnippets.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/PageSnippets.kt
@@ -1,0 +1,168 @@
+package jp.jig.sabera.app.docs.snippets
+
+import app.jigglass.glass.CommandManager
+
+/** ページごとの使い方のコード例。 */
+internal object PageSnippets {
+
+    fun teleprompter(commandManager: CommandManager) {
+        // #snippet pages.teleprompter
+        commandManager.enterTeleprompterPage()
+        commandManager.sendTeleprompterStatus(
+            status = CommandManager.TeleprompterStatus.READY,
+            mode = CommandManager.TeleprompterMode.TELEPROMPT,
+        )
+        commandManager.sendTeleprompterContent("読み上げる原稿", percent = 0)
+        // #endsnippet
+    }
+
+    fun teleprompterPlay(commandManager: CommandManager, lines: List<String>) {
+        // #snippet pages.teleprompter-play
+        commandManager.sendTeleprompterStatus(
+            status = CommandManager.TeleprompterStatus.STARTED,
+            mode = CommandManager.TeleprompterMode.TELEPROMPT,
+        )
+        lines.forEachIndexed { index, line ->
+            // 全文を送り直さず、読み上げた分だけ流す
+            commandManager.sendTeleprompterLine(
+                text = line,
+                percent = (index + 1) * 100 / lines.size,
+            )
+            commandManager.sendTeleprompterTime("00:%02d".format(index))
+        }
+        commandManager.clearInscriptionText()
+        // #endsnippet
+    }
+
+    fun translate(commandManager: CommandManager, sentences: List<String>) {
+        // #snippet pages.translate
+        commandManager.enterTranslatePage()
+        commandManager.sendTranslateLanguage(source = "en", target = "ja")
+        sentences.forEach { sentence ->
+            // 送るたび全文が置き換わる
+            commandManager.sendTranslateContent(sentence)
+        }
+        commandManager.clearInscriptionText()
+        // #endsnippet
+    }
+
+    fun aiChat(commandManager: CommandManager, question: String, answer: String) {
+        // #snippet pages.ai-chat
+        // フォントを先に確定させるため、開く前に言語を送る
+        commandManager.sendAiChatLanguage("JPN")
+        commandManager.enterAiChatPage()
+
+        commandManager.sendAiChatSenderText(sender = CommandManager.AiChatSender.USER, text = question)
+        commandManager.sendAiChatSenderStatus(
+            sender = CommandManager.AiChatSender.AI,
+            status = CommandManager.AiChatStatus.GENERATING,
+        )
+        commandManager.sendAiChatSenderText(sender = CommandManager.AiChatSender.AI, text = answer)
+        commandManager.sendAiChatStatus(CommandManager.AiChatStatus.COMPLETE)
+        // #endsnippet
+    }
+
+    fun aiChatClear(commandManager: CommandManager) {
+        // #snippet pages.ai-chat-clear
+        commandManager.clearAiChat()
+        // #endsnippet
+    }
+
+    fun emptyScreen(commandManager: CommandManager) {
+        // #snippet pages.empty-screen
+        commandManager.enterEmptyScreenPage()
+        commandManager.sendEmptyScreenContent("好きな文字列をそのまま出せる")
+        // #endsnippet
+    }
+
+    fun imageDisplay(commandManager: CommandManager, grayscale: ByteArray) {
+        // #snippet pages.image-display
+        commandManager.enterImageDisplayPage()
+        // 196x196 を超えるとファームが弾いて何も出ない
+        commandManager.sendImage(width = 196, height = 196, grayscale = grayscale)
+        // #endsnippet
+    }
+
+    fun layout(commandManager: CommandManager) {
+        // #snippet pages.layout
+        // 開く操作は要らない。モードを送るとその場で切り替わる
+        commandManager.sendLayout(
+            mode = CommandManager.LayoutMode.QUAD,
+            texts = mapOf(0 to "左上", 1 to "右上", 2 to "左下", 3 to "右下"),
+        )
+        // 分割はそのまま、右下だけ書き換える
+        commandManager.sendLayoutTexts(mapOf(3 to "書き換え"))
+        // 空文字でその領域を消す
+        commandManager.sendLayoutTexts(mapOf(3 to ""))
+        commandManager.closeLayout()
+        // #endsnippet
+    }
+
+    fun canvas(commandManager: CommandManager, photo: ByteArray) {
+        // #snippet pages.canvas
+        commandManager.sendCanvas(
+            listOf(
+                CommandManager.CanvasElement(id = 0, x = 16, y = 8, width = 240, height = 40, text = "見出し"),
+            ),
+        )
+        // 画像はテキストの背面に置かれる
+        commandManager.sendCanvasImage(id = 0, x = 16, y = 84, width = 192, height = 192, grayscale = photo)
+        // 他の要素を残して id 1 だけ足す
+        commandManager.sendCanvasElements(
+            listOf(
+                CommandManager.CanvasElement(id = 1, x = 16, y = 300, width = 240, height = 40, text = "キャプション"),
+            ),
+        )
+        commandManager.closeCanvas()
+        // #endsnippet
+    }
+
+    fun navigation(commandManager: CommandManager, map: ByteArray, courseDegrees: Double) {
+        // #snippet pages.navigation
+        commandManager.enterNavigationPage()
+        commandManager.sendNaviLanguage("JPN")
+        commandManager.sendNaviStatus(CommandManager.NaviStatus.START)
+        commandManager.sendNavi(
+            maneuverIcon = CommandManager.ManeuverIcon.TURN_LEFT,
+            instructionText = "交差点を左折",
+            distanceText = "300m",
+            estimatedArrivalText = "12:34",
+            timeAndDistanceText = "10分 / 1.2km",
+            bitmapWidth = 128,
+            bitmapHeight = 128,
+            grayscale = map,
+        )
+        // 方位のドリフト補正。案内中は数秒おきに送る
+        commandManager.sendNaviCourse(courseDegrees)
+        // 着いたら到着画面に切り替える
+        commandManager.sendNaviStatus(CommandManager.NaviStatus.ARRIVED)
+        // #endsnippet
+    }
+
+    fun angleAdjustment(commandManager: CommandManager) {
+        // #snippet pages.angle-adjustment
+        commandManager.enterGlassAngleAdjustmentPage()
+        commandManager.sendWakeupTiltThreshold(degrees = 20)
+        // #endsnippet
+    }
+
+    fun adjust(commandManager: CommandManager) {
+        // #snippet pages.adjust
+        commandManager.sendAdjust(
+            status = CommandManager.AdjustStatus.SHOW,
+            imageType = CommandManager.AdjustImageType.HOME,
+        )
+        commandManager.sendAdjust(
+            status = CommandManager.AdjustStatus.CLOSE,
+            imageType = CommandManager.AdjustImageType.HOME,
+        )
+        // #endsnippet
+    }
+
+    fun home(commandManager: CommandManager) {
+        // #snippet pages.home
+        // 開いていたページを閉じて表示内容を捨てる
+        commandManager.enterHomePage()
+        // #endsnippet
+    }
+}

--- a/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/PageSnippets.kt
+++ b/samples/kmp/snippets/src/main/kotlin/jp/jig/sabera/app/docs/snippets/PageSnippets.kt
@@ -37,7 +37,7 @@ internal object PageSnippets {
     fun translate(commandManager: CommandManager, sentences: List<String>) {
         // #snippet pages.translate
         commandManager.enterTranslatePage()
-        commandManager.sendTranslateLanguage(source = "en", target = "ja")
+        commandManager.sendTranslateLanguage(source = "ENG", target = "JPN")
         sentences.forEach { sentence ->
             // 送るたび全文が置き換わる
             commandManager.sendTranslateContent(sentence)

--- a/scripts/sync-snippets.py
+++ b/scripts/sync-snippets.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SNIPPET_SRC = ROOT / "samples/kmp/snippets/src/main/kotlin"
-DOCS_API = ROOT / "docs/api"
+DOCS_DIRS = (ROOT / "docs/api", ROOT / "docs/pages")
 
 SNIPPET_RE = re.compile(
     r"^[ \t]*// #snippet[ \t]+(?P<id>\S+)[ \t]*\n(?P<body>.*?)^[ \t]*// #endsnippet[ \t]*$",
@@ -68,7 +68,8 @@ def main():
     stale = []
     updated = 0
 
-    for path in sorted(DOCS_API.rglob("*.md")):
+    targets = sorted(path for directory in DOCS_DIRS for path in directory.rglob("*.md"))
+    for path in targets:
         before = path.read_text(encoding="utf-8")
         after = rewrite(before, snippets, used)
         if after == before:


### PR DESCRIPTION
## 概要

- API リファレンスはメソッド単位なので、あるページで何をどの順に送るのかが追えない。グラスの画面ごとにまとめた入口を用意した
- 対象はテレプロンプター・翻訳・AI アシスタント・汎用テキスト表示・画像表示・分割レイアウト・自由配置キャンバス・ナビ・調整の9ページ。接続手順は Getting Started に任せて省いている
- コード例は他のページと同じくコンパイルの通る Kotlin から写す
- 翻訳の言語コードを3文字に直した。AI チャットとナビと同じ形式で、2文字と書いていたのが誤り

## 動作確認

- [x] ローカルで立ち上げて、サイドバーに「ページごとの使い方」が並び、各ページが開く
- [x] 本文中の API 名が自動でリファレンスへリンクされる
- [x] ページ末尾の前後リンクが途切れない
- [x] `compileDebugKotlin` と `ktlintCheck` が通る
- [x] `sync-snippets.py --check` が通る（貼り先のないスニペットなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)