### PR TITLE
✨ 6DoFとキャンバスを試すサンプル画面を追加する

### DIFF
--- a/samples/kmp/app/build.gradle.kts
+++ b/samples/kmp/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Sabera App SDK
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.7.3")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Compose

--- a/samples/kmp/app/build.gradle.kts
+++ b/samples/kmp/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Sabera App SDK
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.0")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Compose

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +23,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -33,6 +35,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
@@ -60,6 +63,9 @@ private const val MAX_FRAMES = 200
 /** 暗いほど左。グラスは自発光なので、明るい画素を濃い文字にする */
 private const val RAMP = " .:-=+*#%@"
 
+/** 同梱のアスキーアート。1コマ ASCII_ROWS 行ずつ並べたもの */
+private const val BUNDLED_ASSET = "badapple.txt"
+
 /**
  * 動画をアスキーアートにして流す画面。
  * 送り方はかわくだりと同じで、1コマずつ汎用テキスト表示ページを置き換える。
@@ -77,6 +83,8 @@ fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
     var current by remember { mutableStateOf("") }
     var position by remember { mutableStateOf(0) }
     var error by remember { mutableStateOf<String?>(null) }
+    // 白地に黒い影の映像は、そのままだと背景が文字で埋まる
+    var invert by remember { mutableStateOf(false) }
 
     DisposableEffect(commandManager) {
         onDispose { commandManager.enterHomePage() }
@@ -93,7 +101,7 @@ fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
         // デコードは重いので、選んだ時点でまとめて文字に変換しておく
         scope.launch {
             try {
-                frames = decodeAsciiFrames(context, uri)
+                frames = decodeAsciiFrames(context, uri, invert)
             } catch (e: Throwable) {
                 Log.e(TAG, "decodeAsciiFrames failed", e)
                 error = e.message
@@ -135,6 +143,23 @@ fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
 
             Button(
                 onClick = {
+                    playing = false
+                    position = 0
+                    error = null
+                    try {
+                        frames = loadBundledFrames(context)
+                    } catch (e: Throwable) {
+                        Log.e(TAG, "loadBundledFrames failed", e)
+                        error = "同梱データを読めなかった: ${e.message}"
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("同梱の Bad Apple を読む")
+            }
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = {
                     picker.launch(
                         PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly),
                     )
@@ -144,7 +169,11 @@ fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
             ) {
                 Text(if (loading) "変換中..." else "動画を選ぶ")
             }
-            Spacer(Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Switch(checked = invert, onCheckedChange = { invert = it })
+                Spacer(Modifier.height(8.dp))
+                Text("明暗を反転して変換する", style = MaterialTheme.typography.bodySmall)
+            }
             Button(
                 onClick = {
                     playing = !playing
@@ -189,7 +218,12 @@ fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
     }
 }
 
-private suspend fun decodeAsciiFrames(context: Context, uri: Uri): List<String> = withContext(Dispatchers.IO) {
+private fun loadBundledFrames(context: Context): List<String> =
+    context.assets.open(BUNDLED_ASSET).bufferedReader().useLines { lines ->
+        lines.chunked(ASCII_ROWS).map { rows -> rows.joinToString("\n") { it.trimEnd() } }.toList()
+    }
+
+private suspend fun decodeAsciiFrames(context: Context, uri: Uri, invert: Boolean): List<String> = withContext(Dispatchers.IO) {
     val retriever = MediaMetadataRetriever()
     try {
         retriever.setDataSource(context, uri)
@@ -204,14 +238,14 @@ private suspend fun decodeAsciiFrames(context: Context, uri: Uri): List<String> 
                 MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
                 ASCII_COLUMNS,
                 ASCII_ROWS,
-            )?.toAsciiFrame()
+            )?.toAsciiFrame(invert)
         }
     } finally {
         retriever.release()
     }
 }
 
-private fun Bitmap.toAsciiFrame(): String =
+private fun Bitmap.toAsciiFrame(invert: Boolean): String =
     (0 until height).joinToString("\n") { y ->
         buildString {
             for (x in 0 until width) {
@@ -219,7 +253,8 @@ private fun Bitmap.toAsciiFrame(): String =
                 val luminance = 0.299 * Color.red(color) +
                     0.587 * Color.green(color) +
                     0.114 * Color.blue(color)
-                append(RAMP[luminance.toInt().coerceIn(0, 255) * (RAMP.length - 1) / 255])
+                val level = luminance.toInt().coerceIn(0, 255).let { if (invert) 255 - it else it }
+                append(RAMP[level * (RAMP.length - 1) / 255])
             }
         }.trimEnd()
     }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
@@ -1,0 +1,225 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import app.jigglass.glass.GlassClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.min
+
+private const val TAG = "AsciiVideoScreen"
+
+/** かわくだりの盤面と同じ大きさ。汎用テキスト表示ページに収まる文字数 */
+private const val ASCII_COLUMNS = 20
+private const val ASCII_ROWS = 8
+
+/** 1コマの表示時間。送信が追いつく範囲で選ぶ */
+private const val FRAME_INTERVAL_MS = 200L
+
+/** 変換の待ち時間と端末のメモリを抑えるための上限。200コマで40秒ぶん */
+private const val MAX_FRAMES = 200
+
+/** 暗いほど左。グラスは自発光なので、明るい画素を濃い文字にする */
+private const val RAMP = " .:-=+*#%@"
+
+/**
+ * 動画をアスキーアートにして流す画面。
+ * 送り方はかわくだりと同じで、1コマずつ汎用テキスト表示ページを置き換える。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AsciiVideoScreen(client: GlassClient, onBack: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val commandManager = remember(client) { client.createCommandManager() }
+
+    var frames by remember { mutableStateOf<List<String>>(emptyList()) }
+    var loading by remember { mutableStateOf(false) }
+    var playing by remember { mutableStateOf(false) }
+    var current by remember { mutableStateOf("") }
+    var position by remember { mutableStateOf(0) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    DisposableEffect(commandManager) {
+        onDispose { commandManager.enterHomePage() }
+    }
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        uri ?: return@rememberLauncherForActivityResult
+        playing = false
+        loading = true
+        error = null
+        frames = emptyList()
+        // デコードは重いので、選んだ時点でまとめて文字に変換しておく
+        scope.launch {
+            try {
+                frames = decodeAsciiFrames(context, uri)
+            } catch (e: Throwable) {
+                Log.e(TAG, "decodeAsciiFrames failed", e)
+                error = e.message
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    LaunchedEffect(playing) {
+        if (!playing || frames.isEmpty()) return@LaunchedEffect
+
+        commandManager.enterEmptyScreenPage()
+        while (isActive) {
+            val frame = frames[position % frames.size]
+            current = frame
+            commandManager.sendEmptyScreenContent(frame)
+            position++
+            delay(FRAME_INTERVAL_MS)
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("アスキーアートを流す") }) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "選んだ動画を ${ASCII_COLUMNS}×${ASCII_ROWS} の文字に落として、" +
+                    "${FRAME_INTERVAL_MS}ms ごとに送る。Bad Apple!! のような影絵がいちばん形になる。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    picker.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly),
+                    )
+                },
+                enabled = !loading,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (loading) "変換中..." else "動画を選ぶ")
+            }
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = {
+                    playing = !playing
+                    if (!playing) position = 0
+                },
+                enabled = frames.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (playing) "止める" else "流す")
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                if (frames.isEmpty()) "まだ動画がない" else "${frames.size} コマ / 再生位置 ${position % frames.size}",
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            error?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            Text(
+                current.ifEmpty { frames.firstOrNull() ?: "" },
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = FontFamily.Monospace,
+            )
+
+            Spacer(Modifier.height(24.dp))
+            OutlinedButton(
+                onClick = {
+                    playing = false
+                    onBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("戻る")
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+private suspend fun decodeAsciiFrames(context: Context, uri: Uri): List<String> = withContext(Dispatchers.IO) {
+    val retriever = MediaMetadataRetriever()
+    try {
+        retriever.setDataSource(context, uri)
+        val durationMs = retriever
+            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            ?.toLongOrNull() ?: 0L
+        val count = min(MAX_FRAMES, (durationMs / FRAME_INTERVAL_MS).toInt())
+        // 小さく取り出せばデコードも縮小もファームに任せず済む
+        (0 until count).mapNotNull { index ->
+            retriever.getScaledFrameAtTime(
+                index * FRAME_INTERVAL_MS * 1000,
+                MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+                ASCII_COLUMNS,
+                ASCII_ROWS,
+            )?.toAsciiFrame()
+        }
+    } finally {
+        retriever.release()
+    }
+}
+
+private fun Bitmap.toAsciiFrame(): String =
+    (0 until height).joinToString("\n") { y ->
+        buildString {
+            for (x in 0 until width) {
+                val color = getPixel(x, y)
+                val luminance = 0.299 * Color.red(color) +
+                    0.587 * Color.green(color) +
+                    0.114 * Color.blue(color)
+                append(RAMP[luminance.toInt().coerceIn(0, 255) * (RAMP.length - 1) / 255])
+            }
+        }.trimEnd()
+    }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/AsciiVideoScreen.kt
@@ -55,7 +55,7 @@ private const val ASCII_COLUMNS = 20
 private const val ASCII_ROWS = 8
 
 /** 1コマの表示時間。送信が追いつく範囲で選ぶ */
-private const val FRAME_INTERVAL_MS = 200L
+private const val FRAME_INTERVAL_MS = 100L
 
 /** 変換の待ち時間と端末のメモリを抑えるための上限。200コマで40秒ぶん */
 private const val MAX_FRAMES = 200

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BadApple.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BadApple.kt
@@ -1,0 +1,38 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.content.Context
+
+/** 同梱データの寸法。ここから間引いて小さいコマを作る */
+const val BAD_APPLE_WIDTH = 320
+const val BAD_APPLE_HEIGHT = 240
+
+private const val BAD_APPLE_PIXELS = BAD_APPLE_WIDTH * BAD_APPLE_HEIGHT
+private const val PACKED_FRAME_BYTES = BAD_APPLE_PIXELS / 8
+private const val BAD_APPLE_ASSET = "badapple320.bin"
+
+/** 1画素1bitに詰めたコマの列。1コマ $PACKED_FRAME_BYTES バイトで並んでいる */
+fun loadBadAppleFrames(context: Context): List<ByteArray> {
+    val bytes = context.assets.open(BAD_APPLE_ASSET).use { it.readBytes() }
+    return (0 until bytes.size / PACKED_FRAME_BYTES).map { index ->
+        bytes.copyOfRange(index * PACKED_FRAME_BYTES, (index + 1) * PACKED_FRAME_BYTES)
+    }
+}
+
+/** 1コマを SDK が受け取る1画素1バイトへ戻し、指定の寸法へ縮める */
+fun badAppleFrame(packed: ByteArray, width: Int, height: Int): ByteArray {
+    val source = unpackBits(packed, BAD_APPLE_PIXELS)
+    if (width == BAD_APPLE_WIDTH && height == BAD_APPLE_HEIGHT) return source
+    return shrink(source, BAD_APPLE_WIDTH, BAD_APPLE_HEIGHT, width, height)
+}
+
+/** 間引きだけの縮小。2値なので補間すると中間の階調が出て輪郭が甘くなる */
+private fun shrink(source: ByteArray, srcWidth: Int, srcHeight: Int, dstWidth: Int, dstHeight: Int): ByteArray {
+    val out = ByteArray(dstWidth * dstHeight)
+    for (y in 0 until dstHeight) {
+        val srcRow = y * srcHeight / dstHeight * srcWidth
+        for (x in 0 until dstWidth) {
+            out[y * dstWidth + x] = source[srcRow + x * srcWidth / dstWidth]
+        }
+    }
+    return out
+}

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BinaryVideoScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BinaryVideoScreen.kt
@@ -1,0 +1,178 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import app.jigglass.glass.GlassClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+
+private const val TAG = "BinaryVideoScreen"
+
+/** 4:3 の 96x72。196角までは送れるが、小さいほど1コマの転送が短い */
+private const val FRAME_WIDTH = 96
+private const val FRAME_HEIGHT = 72
+
+/** 1画素1bitに詰めた1コマの大きさ */
+private const val PACKED_FRAME_BYTES = FRAME_WIDTH * FRAME_HEIGHT / 8
+
+/** 1コマの表示時間。画像は数百バイトずつ分割して送られるので文字より遅い */
+private const val FRAME_INTERVAL_MS = 400L
+
+private const val BUNDLED_ASSET = "badapple.bin"
+
+/**
+ * 2値の画像をそのまま流す画面。
+ * アスキーアート版と同じ映像を、文字ではなく画像表示ページへ送る。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
+    val context = LocalContext.current
+    val commandManager = remember(client) { client.createCommandManager() }
+
+    var frames by remember { mutableStateOf<List<ByteArray>>(emptyList()) }
+    var playing by remember { mutableStateOf(false) }
+    var position by remember { mutableStateOf(0) }
+    var preview by remember { mutableStateOf<GrayscaleImage?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    DisposableEffect(commandManager) {
+        onDispose { commandManager.enterHomePage() }
+    }
+
+    LaunchedEffect(Unit) {
+        try {
+            frames = withContext(Dispatchers.IO) { loadPackedFrames(context) }
+        } catch (e: Throwable) {
+            Log.e(TAG, "loadPackedFrames failed", e)
+            error = "同梱データを読めなかった: ${e.message}"
+        }
+    }
+
+    LaunchedEffect(playing) {
+        if (!playing || frames.isEmpty()) return@LaunchedEffect
+
+        commandManager.enterImageDisplayPage()
+        while (isActive) {
+            val pixels = unpack(frames[position % frames.size])
+            preview = GrayscaleImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
+            commandManager.sendImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
+            position++
+            delay(FRAME_INTERVAL_MS)
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("2値画像を流す") }) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "同梱の1bit画像を ${FRAME_WIDTH}×$FRAME_HEIGHT のまま画像表示ページへ送る。" +
+                    "1コマ $PACKED_FRAME_BYTES バイトを展開して ${FRAME_INTERVAL_MS}ms ごとに1枚。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    playing = !playing
+                    if (!playing) position = 0
+                },
+                enabled = frames.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (playing) "止める" else "流す")
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                if (frames.isEmpty()) {
+                    "読み込み中"
+                } else {
+                    "${frames.size} コマ / 再生位置 ${position % frames.size}"
+                },
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            error?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            preview?.let {
+                Image(
+                    bitmap = it.toBitmap().asImageBitmap(),
+                    contentDescription = "いま送っているコマ",
+                    modifier = Modifier.size(288.dp, 216.dp),
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+            OutlinedButton(
+                onClick = {
+                    playing = false
+                    onBack()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("戻る")
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+private fun loadPackedFrames(context: Context): List<ByteArray> {
+    val bytes = context.assets.open(BUNDLED_ASSET).use { it.readBytes() }
+    return (0 until bytes.size / PACKED_FRAME_BYTES).map { index ->
+        bytes.copyOfRange(index * PACKED_FRAME_BYTES, (index + 1) * PACKED_FRAME_BYTES)
+    }
+}
+
+/** 1bitずつ詰めたコマを、SDKが受け取る1画素1バイトへ戻す */
+private fun unpack(frame: ByteArray): ByteArray {
+    val pixels = ByteArray(FRAME_WIDTH * FRAME_HEIGHT)
+    pixels.indices.forEach { index ->
+        val bit = (frame[index / 8].toInt() shr (7 - index % 8)) and 1
+        pixels[index] = if (bit == 1) 0xFF.toByte() else 0
+    }
+    return pixels
+}

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BinaryVideoScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/BinaryVideoScreen.kt
@@ -47,7 +47,7 @@ private const val FRAME_HEIGHT = 72
 private const val PACKED_FRAME_BYTES = FRAME_WIDTH * FRAME_HEIGHT / 8
 
 /** 1コマの表示時間。画像は数百バイトずつ分割して送られるので文字より遅い */
-private const val FRAME_INTERVAL_MS = 400L
+private const val FRAME_INTERVAL_MS = 200L
 
 private const val BUNDLED_ASSET = "badapple.bin"
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
@@ -54,10 +54,10 @@ private const val FRAME_Y = (360 - FRAME_HEIGHT) / 2
 /** 宣言する再生間隔の初期値。グラスはこの間隔でリングからフレームを取り出す */
 private const val INTERVAL_DEFAULT_MS = 100
 
-/** スライダーで動かせる範囲。50ms刻み */
-private const val INTERVAL_MIN_MS = 50f
-private const val INTERVAL_MAX_MS = 500f
-private const val INTERVAL_STEPS = 8
+/** スライダーで動かせる範囲。100msは通ったので、そこから下だけを刻みなしで探る */
+private const val INTERVAL_MIN_MS = 1f
+private const val INTERVAL_MAX_MS = 100f
+private const val INTERVAL_STEPS = 0
 
 private const val BUNDLED_ASSET = "badapple128.bin"
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 private const val TAG = "CanvasAnimationScreen"
 
@@ -49,8 +51,13 @@ private const val PACKED_FRAME_BYTES = PIXEL_COUNT / 8
 private const val FRAME_X = (576 - FRAME_WIDTH) / 2
 private const val FRAME_Y = (360 - FRAME_HEIGHT) / 2
 
-/** 宣言する再生間隔。グラスはこの間隔でリングからフレームを取り出す */
-private const val INTERVAL_MS = 100
+/** 宣言する再生間隔の初期値。グラスはこの間隔でリングからフレームを取り出す */
+private const val INTERVAL_DEFAULT_MS = 100
+
+/** スライダーで動かせる範囲。50ms刻み */
+private const val INTERVAL_MIN_MS = 50f
+private const val INTERVAL_MAX_MS = 500f
+private const val INTERVAL_STEPS = 8
 
 private const val BUNDLED_ASSET = "badapple128.bin"
 
@@ -69,6 +76,9 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
     var position by remember { mutableStateOf(0) }
     var preview by remember { mutableStateOf<GrayscaleImage?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
+    var intervalMs by remember { mutableStateOf(INTERVAL_DEFAULT_MS) }
+    // ドラッグ中に宣言し直すと止まって見えるので、離してから反映する
+    var sliderPosition by remember { mutableStateOf(INTERVAL_DEFAULT_MS.toFloat()) }
 
     DisposableEffect(commandManager) {
         onDispose {
@@ -86,17 +96,18 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
         }
     }
 
-    LaunchedEffect(playing) {
+    LaunchedEffect(playing, intervalMs) {
         if (!playing || frames.isEmpty()) return@LaunchedEffect
 
-        commandManager.startCanvasAnimation(FRAME_X, FRAME_Y, FRAME_WIDTH, FRAME_HEIGHT, INTERVAL_MS)
+        // 間隔はANIM_STARTで宣言するので、変えたら送り直す
+        commandManager.startCanvasAnimation(FRAME_X, FRAME_Y, FRAME_WIDTH, FRAME_HEIGHT, intervalMs)
         try {
             while (isActive) {
                 val pixels = unpackBits(frames[position % frames.size], PIXEL_COUNT)
                 preview = GrayscaleImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
                 commandManager.sendCanvasAnimationFrame(FRAME_WIDTH, FRAME_HEIGHT, pixels)
                 position++
-                delay(INTERVAL_MS.toLong())
+                delay(intervalMs.toLong())
             }
         } finally {
             commandManager.stopCanvasAnimation()
@@ -114,8 +125,8 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                "${FRAME_WIDTH}×$FRAME_HEIGHT を interval=$INTERVAL_MS ms で宣言して、" +
-                    "1コマずつ送り続ける。FEATURE_VERSION 2.3.0 以上のファームが対象。",
+                "${FRAME_WIDTH}×$FRAME_HEIGHT を宣言した interval で送り続ける。" +
+                    "同梱データは10fpsぶんなので、100ms から離すと再生速度も変わる。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
@@ -131,6 +142,18 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
                 Text(if (playing) "止める" else "流す")
             }
             Spacer(Modifier.height(8.dp))
+            Text(
+                "interval = ${sliderPosition.roundToInt()} ms" +
+                    "（約 ${1000 / sliderPosition.roundToInt()} fps）",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Slider(
+                value = sliderPosition,
+                onValueChange = { sliderPosition = it },
+                onValueChangeFinished = { intervalMs = sliderPosition.roundToInt() },
+                valueRange = INTERVAL_MIN_MS..INTERVAL_MAX_MS,
+                steps = INTERVAL_STEPS,
+            )
             Text(
                 if (frames.isEmpty()) {
                     "読み込み中"

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
@@ -1,6 +1,5 @@
 package jp.jig.glasses.sample.kmp.ui
 
-import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -41,25 +40,30 @@ import kotlin.math.roundToInt
 
 private const val TAG = "CanvasAnimationScreen"
 
-/** 4:3 の 128x96。380,000バイトのアリーナを w*h*2 で割ると15枚ぶんのリングになる */
-private const val FRAME_WIDTH = 128
-private const val FRAME_HEIGHT = 96
-private const val PIXEL_COUNT = FRAME_WIDTH * FRAME_HEIGHT
-private const val PACKED_FRAME_BYTES = PIXEL_COUNT / 8
+private const val CANVAS_WIDTH = 576
+private const val CANVAS_HEIGHT = 360
 
-/** キャンバス 576x360 の中央に置く */
-private const val FRAME_X = (576 - FRAME_WIDTH) / 2
-private const val FRAME_Y = (360 - FRAME_HEIGHT) / 2
+/**
+ * 選べる寸法。4:3 のまま、380,000バイトのアリーナに w*h*2 が2枚入る範囲で並べた。
+ * 320x240 が上限で、これ以上大きくするとリングが1枚になって再生が始まらない。
+ */
+private val FRAME_SIZES = listOf(
+    80 to 60,
+    128 to 96,
+    160 to 120,
+    200 to 150,
+    240 to 180,
+    280 to 210,
+    BAD_APPLE_WIDTH to BAD_APPLE_HEIGHT,
+)
 
-/** 宣言する再生間隔の初期値。グラスはこの間隔でリングからフレームを取り出す */
-private const val INTERVAL_DEFAULT_MS = 100
+/** 宣言する再生間隔の初期値 */
+private const val INTERVAL_DEFAULT_MS = 200
 
-/** スライダーで動かせる範囲。100msは通ったので、そこから下だけを刻みなしで探る */
-private const val INTERVAL_MIN_MS = 1f
-private const val INTERVAL_MAX_MS = 100f
+/** スライダーで動かせる範囲。1コマが大きいと転送に時間がかかるので上を広く取る */
+private const val INTERVAL_MIN_MS = 50f
+private const val INTERVAL_MAX_MS = 1000f
 private const val INTERVAL_STEPS = 0
-
-private const val BUNDLED_ASSET = "badapple128.bin"
 
 /**
  * キャンバスのアニメーションで動画を流す画面。
@@ -76,9 +80,12 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
     var position by remember { mutableStateOf(0) }
     var preview by remember { mutableStateOf<GrayscaleImage?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
-    var intervalMs by remember { mutableStateOf(INTERVAL_DEFAULT_MS) }
+
     // ドラッグ中に宣言し直すと止まって見えるので、離してから反映する
-    var sliderPosition by remember { mutableStateOf(INTERVAL_DEFAULT_MS.toFloat()) }
+    var intervalMs by remember { mutableStateOf(INTERVAL_DEFAULT_MS) }
+    var intervalSlider by remember { mutableStateOf(INTERVAL_DEFAULT_MS.toFloat()) }
+    var sizeIndex by remember { mutableStateOf(FRAME_SIZES.lastIndex) }
+    var sizeSlider by remember { mutableStateOf(FRAME_SIZES.lastIndex.toFloat()) }
 
     DisposableEffect(commandManager) {
         onDispose {
@@ -89,23 +96,30 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
 
     LaunchedEffect(Unit) {
         try {
-            frames = withContext(Dispatchers.IO) { loadFrames(context) }
+            frames = withContext(Dispatchers.IO) { loadBadAppleFrames(context) }
         } catch (e: Throwable) {
-            Log.e(TAG, "loadFrames failed", e)
+            Log.e(TAG, "loadBadAppleFrames failed", e)
             error = "同梱データを読めなかった: ${e.message}"
         }
     }
 
-    LaunchedEffect(playing, intervalMs) {
+    LaunchedEffect(playing, intervalMs, sizeIndex) {
         if (!playing || frames.isEmpty()) return@LaunchedEffect
 
-        // 間隔はANIM_STARTで宣言するので、変えたら送り直す
-        commandManager.startCanvasAnimation(FRAME_X, FRAME_Y, FRAME_WIDTH, FRAME_HEIGHT, intervalMs)
+        val (width, height) = FRAME_SIZES[sizeIndex]
+        // 寸法と間隔はANIM_STARTで宣言するので、変えたら送り直す
+        commandManager.startCanvasAnimation(
+            x = (CANVAS_WIDTH - width) / 2,
+            y = (CANVAS_HEIGHT - height) / 2,
+            width = width,
+            height = height,
+            intervalMs = intervalMs,
+        )
         try {
             while (isActive) {
-                val pixels = unpackBits(frames[position % frames.size], PIXEL_COUNT)
-                preview = GrayscaleImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
-                commandManager.sendCanvasAnimationFrame(FRAME_WIDTH, FRAME_HEIGHT, pixels)
+                val pixels = badAppleFrame(frames[position % frames.size], width, height)
+                preview = GrayscaleImage(width, height, pixels)
+                commandManager.sendCanvasAnimationFrame(width, height, pixels)
                 position++
                 delay(intervalMs.toLong())
             }
@@ -125,8 +139,8 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                "${FRAME_WIDTH}×$FRAME_HEIGHT を宣言した interval で送り続ける。" +
-                    "同梱データは10fpsぶんなので、100ms から離すと再生速度も変わる。",
+                "4:3 のまま寸法と interval を選んで送り続ける。同梱データは ${BAD_APPLE_WIDTH}×$BAD_APPLE_HEIGHT の5fpsぶんで、" +
+                    "小さい寸法は間引いて作る。FEATURE_VERSION 2.3.0 以上のファームが対象。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
@@ -141,16 +155,31 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
             ) {
                 Text(if (playing) "止める" else "流す")
             }
+
+            val (sliderWidth, sliderHeight) = FRAME_SIZES[sizeSlider.roundToInt()]
             Spacer(Modifier.height(8.dp))
             Text(
-                "interval = ${sliderPosition.roundToInt()} ms" +
-                    "（約 ${1000 / sliderPosition.roundToInt()} fps）",
+                "サイズ = ${sliderWidth}×$sliderHeight" +
+                    "（リング ${380_000 / (sliderWidth * sliderHeight * 2)} 枚）",
                 style = MaterialTheme.typography.bodyMedium,
             )
             Slider(
-                value = sliderPosition,
-                onValueChange = { sliderPosition = it },
-                onValueChangeFinished = { intervalMs = sliderPosition.roundToInt() },
+                value = sizeSlider,
+                onValueChange = { sizeSlider = it },
+                onValueChangeFinished = { sizeIndex = sizeSlider.roundToInt() },
+                valueRange = 0f..FRAME_SIZES.lastIndex.toFloat(),
+                steps = FRAME_SIZES.size - 2,
+            )
+
+            Text(
+                "interval = ${intervalSlider.roundToInt()} ms" +
+                    "（約 ${1000 / intervalSlider.roundToInt()} fps）",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Slider(
+                value = intervalSlider,
+                onValueChange = { intervalSlider = it },
+                onValueChangeFinished = { intervalMs = intervalSlider.roundToInt() },
                 valueRange = INTERVAL_MIN_MS..INTERVAL_MAX_MS,
                 steps = INTERVAL_STEPS,
             )
@@ -219,12 +248,5 @@ fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
             }
             Spacer(Modifier.height(24.dp))
         }
-    }
-}
-
-private fun loadFrames(context: Context): List<ByteArray> {
-    val bytes = context.assets.open(BUNDLED_ASSET).use { it.readBytes() }
-    return (0 until bytes.size / PACKED_FRAME_BYTES).map { index ->
-        bytes.copyOfRange(index * PACKED_FRAME_BYTES, (index + 1) * PACKED_FRAME_BYTES)
     }
 }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasAnimationScreen.kt
@@ -37,27 +37,30 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 
-private const val TAG = "BinaryVideoScreen"
+private const val TAG = "CanvasAnimationScreen"
 
-/** 4:3 の 96x72。196角までは送れるが、小さいほど1コマの転送が短い */
-private const val FRAME_WIDTH = 96
-private const val FRAME_HEIGHT = 72
+/** 4:3 の 128x96。380,000バイトのアリーナを w*h*2 で割ると15枚ぶんのリングになる */
+private const val FRAME_WIDTH = 128
+private const val FRAME_HEIGHT = 96
+private const val PIXEL_COUNT = FRAME_WIDTH * FRAME_HEIGHT
+private const val PACKED_FRAME_BYTES = PIXEL_COUNT / 8
 
-/** 1画素1bitに詰めた1コマの大きさ */
-private const val PACKED_FRAME_BYTES = FRAME_WIDTH * FRAME_HEIGHT / 8
+/** キャンバス 576x360 の中央に置く */
+private const val FRAME_X = (576 - FRAME_WIDTH) / 2
+private const val FRAME_Y = (360 - FRAME_HEIGHT) / 2
 
-/** 1コマの表示時間。画像は数百バイトずつ分割して送られるので文字より遅い */
-private const val FRAME_INTERVAL_MS = 200L
+/** 宣言する再生間隔。グラスはこの間隔でリングからフレームを取り出す */
+private const val INTERVAL_MS = 100
 
-private const val BUNDLED_ASSET = "badapple.bin"
+private const val BUNDLED_ASSET = "badapple128.bin"
 
 /**
- * 2値の画像をそのまま流す画面。
- * アスキーアート版と同じ映像を、文字ではなく画像表示ページへ送る。
+ * キャンバスのアニメーションで動画を流す画面。
+ * FEATURE_VERSION 2.3.0 で入った ANIM_START / ANIM_FRAME / ANIM_STOP を通す。
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
+fun CanvasAnimationScreen(client: GlassClient, onBack: () -> Unit) {
     val context = LocalContext.current
     val commandManager = remember(client) { client.createCommandManager() }
 
@@ -68,14 +71,17 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
     var error by remember { mutableStateOf<String?>(null) }
 
     DisposableEffect(commandManager) {
-        onDispose { commandManager.enterHomePage() }
+        onDispose {
+            commandManager.stopCanvasAnimation()
+            commandManager.closeCanvas()
+        }
     }
 
     LaunchedEffect(Unit) {
         try {
-            frames = withContext(Dispatchers.IO) { loadPackedFrames(context) }
+            frames = withContext(Dispatchers.IO) { loadFrames(context) }
         } catch (e: Throwable) {
-            Log.e(TAG, "loadPackedFrames failed", e)
+            Log.e(TAG, "loadFrames failed", e)
             error = "同梱データを読めなかった: ${e.message}"
         }
     }
@@ -83,18 +89,22 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
     LaunchedEffect(playing) {
         if (!playing || frames.isEmpty()) return@LaunchedEffect
 
-        commandManager.enterImageDisplayPage()
-        while (isActive) {
-            val pixels = unpackBits(frames[position % frames.size], FRAME_WIDTH * FRAME_HEIGHT)
-            preview = GrayscaleImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
-            commandManager.sendImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
-            position++
-            delay(FRAME_INTERVAL_MS)
+        commandManager.startCanvasAnimation(FRAME_X, FRAME_Y, FRAME_WIDTH, FRAME_HEIGHT, INTERVAL_MS)
+        try {
+            while (isActive) {
+                val pixels = unpackBits(frames[position % frames.size], PIXEL_COUNT)
+                preview = GrayscaleImage(FRAME_WIDTH, FRAME_HEIGHT, pixels)
+                commandManager.sendCanvasAnimationFrame(FRAME_WIDTH, FRAME_HEIGHT, pixels)
+                position++
+                delay(INTERVAL_MS.toLong())
+            }
+        } finally {
+            commandManager.stopCanvasAnimation()
         }
     }
 
     Scaffold(
-        topBar = { TopAppBar(title = { Text("2値画像を流す") }) },
+        topBar = { TopAppBar(title = { Text("キャンバスに動画を流す") }) },
     ) { padding ->
         Column(
             modifier = Modifier
@@ -104,8 +114,8 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                "同梱の1bit画像を ${FRAME_WIDTH}×$FRAME_HEIGHT のまま画像表示ページへ送る。" +
-                    "1コマ $PACKED_FRAME_BYTES バイトを展開して ${FRAME_INTERVAL_MS}ms ごとに1枚。",
+                "${FRAME_WIDTH}×$FRAME_HEIGHT を interval=$INTERVAL_MS ms で宣言して、" +
+                    "1コマずつ送り続ける。FEATURE_VERSION 2.3.0 以上のファームが対象。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
@@ -125,7 +135,7 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
                 if (frames.isEmpty()) {
                     "読み込み中"
                 } else {
-                    "${frames.size} コマ / 再生位置 ${position % frames.size}"
+                    "${frames.size} コマ / 送った数 $position"
                 },
                 style = MaterialTheme.typography.bodySmall,
             )
@@ -137,11 +147,40 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))
 
+            Text("流している間に割り込ませて挙動を見る", style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = { commandManager.clearCanvas() },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("clearCanvas を送る")
+            }
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = {
+                    // アリーナ共用なので、静的ビットマップを送るとアニメは止まる
+                    val pattern = testPatternImage(96)
+                    commandManager.sendCanvasImage(
+                        id = 0,
+                        x = 16,
+                        y = 16,
+                        width = pattern.width,
+                        height = pattern.height,
+                        grayscale = pattern.pixels,
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("静的な画像を1枚置く")
+            }
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
             preview?.let {
                 Image(
                     bitmap = it.toBitmap().asImageBitmap(),
                     contentDescription = "いま送っているコマ",
-                    modifier = Modifier.size(288.dp, 216.dp),
+                    modifier = Modifier.size(256.dp, 192.dp),
                 )
             }
 
@@ -160,7 +199,7 @@ fun BinaryVideoScreen(client: GlassClient, onBack: () -> Unit) {
     }
 }
 
-private fun loadPackedFrames(context: Context): List<ByteArray> {
+private fun loadFrames(context: Context): List<ByteArray> {
     val bytes = context.assets.open(BUNDLED_ASSET).use { it.readBytes() }
     return (0 until bytes.size / PACKED_FRAME_BYTES).map { index ->
         bytes.copyOfRange(index * PACKED_FRAME_BYTES, (index + 1) * PACKED_FRAME_BYTES)

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasScreen.kt
@@ -67,12 +67,22 @@ private const val CANVAS_IMAGE_MAX_SIZE = 240
 /** 複数枚を並べるデモ。64角なら四隅に置いてもバッファに余裕がある */
 private const val TILED_IMAGE_SIZE = 64
 
-/** 画像1枚をアニメに差し替えるデモ。左上の画像と同じ位置に置く */
-private const val ANIM_WIDTH = 128
-private const val ANIM_HEIGHT = 96
-private const val ANIM_X = 16
-private const val ANIM_Y = 16
+/**
+ * 静止画と動画を並べて流すデモ。アニメ中は静的なビットマップを置けないので、
+ * 1枚のコマに左右へ並べて描いてから送る。テキスト要素だけは別に置ける。
+ */
+private const val ANIM_WIDTH = 320
+private const val ANIM_HEIGHT = 120
+private const val ANIM_X = (CANVAS_WIDTH - ANIM_WIDTH) / 2
+private const val ANIM_Y = 40
 private const val ANIM_INTERVAL_MS = 200
+
+/** コマの左に置く静止画と、右に流す動画。動画は 4:3 に合わせる */
+private const val ANIM_STILL_SIZE = 120
+private const val ANIM_MOVIE_WIDTH = 160
+
+/** 並べたことが分かるように添えるテキスト。デモ要素と当たらない id を使う */
+private const val ANIM_TEXT_ID = 7
 
 /** 縞の太さを変えて、どの id がどこに出たか見分けられるようにする */
 private val TILED_IMAGES = listOf(
@@ -130,15 +140,30 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
         if (!animating) return@LaunchedEffect
 
         val frames = withContext(Dispatchers.IO) { loadBadAppleFrames(context) }
-        // アリーナ共用なので、ここで置いてある静的画像は破棄される。テキスト要素は残る
+        val still = stripePatternImage(size = ANIM_STILL_SIZE, stripeWidth = 8)
+
+        // アリーナ共用なので、置いてある静的画像はここで破棄される。テキスト要素は残る
         commandManager.startCanvasAnimation(ANIM_X, ANIM_Y, ANIM_WIDTH, ANIM_HEIGHT, ANIM_INTERVAL_MS)
+        commandManager.sendCanvasElements(
+            listOf(
+                CommandManager.CanvasElement(
+                    id = ANIM_TEXT_ID,
+                    x = ANIM_X,
+                    y = ANIM_Y + ANIM_HEIGHT + 8,
+                    width = ANIM_WIDTH,
+                    height = 40,
+                    text = "左は静止画 / 右は動画 / これはテキスト要素",
+                ),
+            ),
+        )
         var index = 0
         try {
             while (isActive) {
+                val movie = badAppleFrame(frames[index % frames.size], ANIM_MOVIE_WIDTH, ANIM_HEIGHT)
                 commandManager.sendCanvasAnimationFrame(
                     width = ANIM_WIDTH,
                     height = ANIM_HEIGHT,
-                    grayscale = badAppleFrame(frames[index % frames.size], ANIM_WIDTH, ANIM_HEIGHT),
+                    grayscale = composeFrame(still, movie),
                 )
                 index++
                 delay(ANIM_INTERVAL_MS.toLong())
@@ -368,8 +393,8 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
 
             Text("アニメーション", style = MaterialTheme.typography.titleMedium)
             Text(
-                "画像1枚のかわりに動画を流す。テキスト要素は残るが、" +
-                    "バッファを共有しているので置いてある画像は消える。" +
+                "アニメと静的な画像はバッファを共有していて同時に置けないので、" +
+                    "静止画と動画を1枚のコマに並べて描いてから流す。テキスト要素は別に置ける。" +
                     "FEATURE_VERSION 2.3.0 以上のファームが対象。",
                 style = MaterialTheme.typography.bodySmall,
             )
@@ -382,7 +407,7 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
                     if (animating) {
                         "アニメを止める"
                     } else {
-                        "左上を ${ANIM_WIDTH}×$ANIM_HEIGHT のアニメにする"
+                        "画像とアニメとテキストを並べる"
                     },
                 )
             }
@@ -423,6 +448,26 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
             }
             Spacer(Modifier.height(24.dp))
         }
+    }
+}
+
+/** 静止画と動画のコマを1枚に並べる。左に静止画、右に動画 */
+private fun composeFrame(still: GrayscaleImage, movie: ByteArray): ByteArray {
+    val frame = ByteArray(ANIM_WIDTH * ANIM_HEIGHT)
+    blit(frame, still.pixels, still.width, still.height, x = 0)
+    blit(frame, movie, ANIM_MOVIE_WIDTH, ANIM_HEIGHT, x = ANIM_WIDTH - ANIM_MOVIE_WIDTH)
+    return frame
+}
+
+/** 行ごとにコピーする。コマの高さに収まらない分は切る */
+private fun blit(frame: ByteArray, source: ByteArray, width: Int, height: Int, x: Int) {
+    for (row in 0 until minOf(height, ANIM_HEIGHT)) {
+        source.copyInto(
+            destination = frame,
+            destinationOffset = row * ANIM_WIDTH + x,
+            startIndex = row * width,
+            endIndex = (row + 1) * width,
+        )
     }
 }
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CanvasScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,6 +44,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import app.jigglass.glass.CommandManager
 import app.jigglass.glass.GlassClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 
 private const val TAG = "CanvasScreen"
 
@@ -61,6 +66,13 @@ private const val CANVAS_IMAGE_MAX_SIZE = 240
 
 /** 複数枚を並べるデモ。64角なら四隅に置いてもバッファに余裕がある */
 private const val TILED_IMAGE_SIZE = 64
+
+/** 画像1枚をアニメに差し替えるデモ。左上の画像と同じ位置に置く */
+private const val ANIM_WIDTH = 128
+private const val ANIM_HEIGHT = 96
+private const val ANIM_X = 16
+private const val ANIM_Y = 16
+private const val ANIM_INTERVAL_MS = 200
 
 /** 縞の太さを変えて、どの id がどこに出たか見分けられるようにする */
 private val TILED_IMAGES = listOf(
@@ -100,6 +112,7 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
     var imageX by remember { mutableStateOf(100) }
     var imageY by remember { mutableStateOf(50) }
     var error by remember { mutableStateOf<String?>(null) }
+    var animating by remember { mutableStateOf(false) }
 
     val used = elements.sumOf { it.text.toByteArray().size + ELEMENT_OVERHEAD_BYTES }
 
@@ -110,6 +123,28 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
         } catch (e: Throwable) {
             Log.e(TAG, "safeRun: $label FAILED", e)
             error = e.message
+        }
+    }
+
+    LaunchedEffect(animating) {
+        if (!animating) return@LaunchedEffect
+
+        val frames = withContext(Dispatchers.IO) { loadBadAppleFrames(context) }
+        // アリーナ共用なので、ここで置いてある静的画像は破棄される。テキスト要素は残る
+        commandManager.startCanvasAnimation(ANIM_X, ANIM_Y, ANIM_WIDTH, ANIM_HEIGHT, ANIM_INTERVAL_MS)
+        var index = 0
+        try {
+            while (isActive) {
+                commandManager.sendCanvasAnimationFrame(
+                    width = ANIM_WIDTH,
+                    height = ANIM_HEIGHT,
+                    grayscale = badAppleFrame(frames[index % frames.size], ANIM_WIDTH, ANIM_HEIGHT),
+                )
+                index++
+                delay(ANIM_INTERVAL_MS.toLong())
+            }
+        } finally {
+            commandManager.stopCanvasAnimation()
         }
     }
 
@@ -327,6 +362,29 @@ fun CanvasScreen(client: GlassClient, onBack: () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("id $imageId の画像を消す")
+            }
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            Text("アニメーション", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "画像1枚のかわりに動画を流す。テキスト要素は残るが、" +
+                    "バッファを共有しているので置いてある画像は消える。" +
+                    "FEATURE_VERSION 2.3.0 以上のファームが対象。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = { animating = !animating },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    if (animating) {
+                        "アニメを止める"
+                    } else {
+                        "左上を ${ANIM_WIDTH}×$ANIM_HEIGHT のアニメにする"
+                    },
+                )
             }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -53,6 +53,7 @@ fun CommandScreen(
     onOpenMicScreen: () -> Unit,
     onOpenLayoutScreen: () -> Unit,
     onOpenCanvasScreen: () -> Unit,
+    onOpenKawakudariScreen: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
@@ -112,6 +113,7 @@ fun CommandScreen(
             SectionTitle("その他")
             CommandButton("6DoF を受け取る画面へ", onClick = onOpenImuScreen)
             CommandButton("マイクを受け取る画面へ", onClick = onOpenMicScreen)
+            CommandButton("かわくだりで遊ぶ画面へ", onClick = onOpenKawakudariScreen)
             CommandButton("Home に戻す") { safeRun("enterHomePage") { commandManager.enterHomePage() } }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -56,6 +56,7 @@ fun CommandScreen(
     onOpenKawakudariScreen: () -> Unit,
     onOpenLauncherScreen: () -> Unit,
     onOpenAsciiVideoScreen: () -> Unit,
+    onOpenBinaryVideoScreen: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
@@ -118,6 +119,7 @@ fun CommandScreen(
             CommandButton("かわくだりで遊ぶ画面へ", onClick = onOpenKawakudariScreen)
             CommandButton("ランチャーの画面へ", onClick = onOpenLauncherScreen)
             CommandButton("アスキーアートを流す画面へ", onClick = onOpenAsciiVideoScreen)
+            CommandButton("2値画像を流す画面へ", onClick = onOpenBinaryVideoScreen)
             CommandButton("Home に戻す") { safeRun("enterHomePage") { commandManager.enterHomePage() } }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -54,6 +54,7 @@ fun CommandScreen(
     onOpenLayoutScreen: () -> Unit,
     onOpenCanvasScreen: () -> Unit,
     onOpenKawakudariScreen: () -> Unit,
+    onOpenLauncherScreen: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
@@ -114,6 +115,7 @@ fun CommandScreen(
             CommandButton("6DoF を受け取る画面へ", onClick = onOpenImuScreen)
             CommandButton("マイクを受け取る画面へ", onClick = onOpenMicScreen)
             CommandButton("かわくだりで遊ぶ画面へ", onClick = onOpenKawakudariScreen)
+            CommandButton("ランチャーの画面へ", onClick = onOpenLauncherScreen)
             CommandButton("Home に戻す") { safeRun("enterHomePage") { commandManager.enterHomePage() } }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -57,6 +57,7 @@ fun CommandScreen(
     onOpenLauncherScreen: () -> Unit,
     onOpenAsciiVideoScreen: () -> Unit,
     onOpenBinaryVideoScreen: () -> Unit,
+    onOpenCanvasAnimationScreen: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
@@ -120,6 +121,7 @@ fun CommandScreen(
             CommandButton("ランチャーの画面へ", onClick = onOpenLauncherScreen)
             CommandButton("アスキーアートを流す画面へ", onClick = onOpenAsciiVideoScreen)
             CommandButton("2値画像を流す画面へ", onClick = onOpenBinaryVideoScreen)
+            CommandButton("キャンバスに動画を流す画面へ", onClick = onOpenCanvasAnimationScreen)
             CommandButton("Home に戻す") { safeRun("enterHomePage") { commandManager.enterHomePage() } }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/CommandScreen.kt
@@ -55,6 +55,7 @@ fun CommandScreen(
     onOpenCanvasScreen: () -> Unit,
     onOpenKawakudariScreen: () -> Unit,
     onOpenLauncherScreen: () -> Unit,
+    onOpenAsciiVideoScreen: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
@@ -116,6 +117,7 @@ fun CommandScreen(
             CommandButton("マイクを受け取る画面へ", onClick = onOpenMicScreen)
             CommandButton("かわくだりで遊ぶ画面へ", onClick = onOpenKawakudariScreen)
             CommandButton("ランチャーの画面へ", onClick = onOpenLauncherScreen)
+            CommandButton("アスキーアートを流す画面へ", onClick = onOpenAsciiVideoScreen)
             CommandButton("Home に戻す") { safeRun("enterHomePage") { commandManager.enterHomePage() } }
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassImage.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassImage.kt
@@ -73,3 +73,13 @@ fun stripePatternImage(size: Int, stripeWidth: Int): GrayscaleImage {
     }
     return GrayscaleImage(size, size, pixels)
 }
+
+/** 1bitずつ詰めた画像を、SDKが受け取る1画素1バイトへ戻す。MSBが左端 */
+fun unpackBits(packed: ByteArray, pixelCount: Int): ByteArray {
+    val pixels = ByteArray(pixelCount)
+    pixels.indices.forEach { index ->
+        val bit = (packed[index / 8].toInt() shr (7 - index % 8)) and 1
+        pixels[index] = if (bit == 1) 0xFF.toByte() else 0
+    }
+    return pixels
+}

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -19,6 +19,7 @@ private enum class ConnectedScreen {
     MIC,
     LAYOUT,
     CANVAS,
+    KAWAKUDARI,
 }
 
 @Composable
@@ -45,6 +46,7 @@ fun GlassesApp(manager: GlassManager) {
             onOpenMicScreen = { screen = ConnectedScreen.MIC },
             onOpenLayoutScreen = { screen = ConnectedScreen.LAYOUT },
             onOpenCanvasScreen = { screen = ConnectedScreen.CANVAS },
+            onOpenKawakudariScreen = { screen = ConnectedScreen.KAWAKUDARI },
         )
 
         ConnectedScreen.TELEPROMPTER -> TeleprompterScreen(
@@ -88,6 +90,11 @@ fun GlassesApp(manager: GlassManager) {
         )
 
         ConnectedScreen.CANVAS -> CanvasScreen(
+            client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
+
+        ConnectedScreen.KAWAKUDARI -> KawakudariScreen(
             client = currentClient,
             onBack = { screen = ConnectedScreen.COMMAND },
         )

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -108,6 +108,9 @@ fun GlassesApp(manager: GlassManager) {
                     LauncherItem.KAWAKUDARI -> ConnectedScreen.KAWAKUDARI
                     LauncherItem.TELEPROMPTER -> ConnectedScreen.TELEPROMPTER
                     LauncherItem.TRANSLATE -> ConnectedScreen.TRANSLATE
+                    LauncherItem.AI_CHAT -> ConnectedScreen.AI_CHAT
+                    LauncherItem.IMAGE -> ConnectedScreen.IMAGE
+                    LauncherItem.IMU -> ConnectedScreen.IMU
                 }
             },
             onBack = { screen = ConnectedScreen.COMMAND },

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -20,6 +20,7 @@ private enum class ConnectedScreen {
     LAYOUT,
     CANVAS,
     KAWAKUDARI,
+    LAUNCHER,
 }
 
 @Composable
@@ -47,6 +48,7 @@ fun GlassesApp(manager: GlassManager) {
             onOpenLayoutScreen = { screen = ConnectedScreen.LAYOUT },
             onOpenCanvasScreen = { screen = ConnectedScreen.CANVAS },
             onOpenKawakudariScreen = { screen = ConnectedScreen.KAWAKUDARI },
+            onOpenLauncherScreen = { screen = ConnectedScreen.LAUNCHER },
         )
 
         ConnectedScreen.TELEPROMPTER -> TeleprompterScreen(
@@ -96,6 +98,18 @@ fun GlassesApp(manager: GlassManager) {
 
         ConnectedScreen.KAWAKUDARI -> KawakudariScreen(
             client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
+
+        ConnectedScreen.LAUNCHER -> LauncherScreen(
+            client = currentClient,
+            onSelect = { item ->
+                screen = when (item) {
+                    LauncherItem.KAWAKUDARI -> ConnectedScreen.KAWAKUDARI
+                    LauncherItem.TELEPROMPTER -> ConnectedScreen.TELEPROMPTER
+                    LauncherItem.TRANSLATE -> ConnectedScreen.TRANSLATE
+                }
+            },
             onBack = { screen = ConnectedScreen.COMMAND },
         )
     }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -21,6 +21,7 @@ private enum class ConnectedScreen {
     CANVAS,
     KAWAKUDARI,
     LAUNCHER,
+    ASCII_VIDEO,
 }
 
 @Composable
@@ -49,6 +50,7 @@ fun GlassesApp(manager: GlassManager) {
             onOpenCanvasScreen = { screen = ConnectedScreen.CANVAS },
             onOpenKawakudariScreen = { screen = ConnectedScreen.KAWAKUDARI },
             onOpenLauncherScreen = { screen = ConnectedScreen.LAUNCHER },
+            onOpenAsciiVideoScreen = { screen = ConnectedScreen.ASCII_VIDEO },
         )
 
         ConnectedScreen.TELEPROMPTER -> TeleprompterScreen(
@@ -97,6 +99,11 @@ fun GlassesApp(manager: GlassManager) {
         )
 
         ConnectedScreen.KAWAKUDARI -> KawakudariScreen(
+            client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
+
+        ConnectedScreen.ASCII_VIDEO -> AsciiVideoScreen(
             client = currentClient,
             onBack = { screen = ConnectedScreen.COMMAND },
         )

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -22,6 +22,7 @@ private enum class ConnectedScreen {
     KAWAKUDARI,
     LAUNCHER,
     ASCII_VIDEO,
+    BINARY_VIDEO,
 }
 
 @Composable
@@ -51,6 +52,7 @@ fun GlassesApp(manager: GlassManager) {
             onOpenKawakudariScreen = { screen = ConnectedScreen.KAWAKUDARI },
             onOpenLauncherScreen = { screen = ConnectedScreen.LAUNCHER },
             onOpenAsciiVideoScreen = { screen = ConnectedScreen.ASCII_VIDEO },
+            onOpenBinaryVideoScreen = { screen = ConnectedScreen.BINARY_VIDEO },
         )
 
         ConnectedScreen.TELEPROMPTER -> TeleprompterScreen(
@@ -104,6 +106,11 @@ fun GlassesApp(manager: GlassManager) {
         )
 
         ConnectedScreen.ASCII_VIDEO -> AsciiVideoScreen(
+            client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
+
+        ConnectedScreen.BINARY_VIDEO -> BinaryVideoScreen(
             client = currentClient,
             onBack = { screen = ConnectedScreen.COMMAND },
         )

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/GlassesApp.kt
@@ -23,6 +23,7 @@ private enum class ConnectedScreen {
     LAUNCHER,
     ASCII_VIDEO,
     BINARY_VIDEO,
+    CANVAS_ANIMATION,
 }
 
 @Composable
@@ -53,6 +54,7 @@ fun GlassesApp(manager: GlassManager) {
             onOpenLauncherScreen = { screen = ConnectedScreen.LAUNCHER },
             onOpenAsciiVideoScreen = { screen = ConnectedScreen.ASCII_VIDEO },
             onOpenBinaryVideoScreen = { screen = ConnectedScreen.BINARY_VIDEO },
+            onOpenCanvasAnimationScreen = { screen = ConnectedScreen.CANVAS_ANIMATION },
         )
 
         ConnectedScreen.TELEPROMPTER -> TeleprompterScreen(
@@ -111,6 +113,11 @@ fun GlassesApp(manager: GlassManager) {
         )
 
         ConnectedScreen.BINARY_VIDEO -> BinaryVideoScreen(
+            client = currentClient,
+            onBack = { screen = ConnectedScreen.COMMAND },
+        )
+
+        ConnectedScreen.CANVAS_ANIMATION -> CanvasAnimationScreen(
             client = currentClient,
             onBack = { screen = ConnectedScreen.COMMAND },
         )

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -40,7 +40,7 @@ import kotlin.random.Random
 
 private const val COLUMNS = 20
 private const val ROWS = 8
-private const val SHIP_ROW = 1
+private const val SHIP_ROW = 3
 private const val TICK_MS = 500L
 
 // 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
@@ -83,7 +83,9 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
         // 遊び始めた向きを中央にする。ヨーは磁力計が無くて絶対値が使えない
         val centerYaw = yaw.filterNotNull().first()
-        val rocks = ArrayDeque(List(ROWS) { NO_ROCK })
+        val rocks = ArrayDeque(List(ROWS) { NONE })
+        // 自機より上の行に残る軌跡。岩と一緒に上へ流れる
+        val trail = ArrayDeque(List(SHIP_ROW) { NONE })
         score = 0
         gameOver = false
         commandManager.enterEmptyScreenPage()
@@ -96,14 +98,16 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
             if (rocks.elementAt(SHIP_ROW) == shipX) {
                 gameOver = true
                 playing = false
-                field = render(rocks, shipX)
+                field = render(rocks, trail, shipX)
                 commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
                 return@LaunchedEffect
             }
 
             score++
-            field = render(rocks, shipX)
+            field = render(rocks, trail, shipX)
             commandManager.sendEmptyScreenContent(field)
+            trail.removeFirst()
+            trail.addLast(shipX)
             delay(TICK_MS)
         }
     }
@@ -154,7 +158,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
     }
 }
 
-private const val NO_ROCK = -1
+private const val NONE = -1
 
 private fun shipColumn(currentYaw: Float, centerYaw: Float): Int {
     val half = (COLUMNS - 1) / 2f
@@ -173,10 +177,11 @@ private fun normalizeDegrees(degrees: Float): Float {
     return value
 }
 
-private fun render(rocks: List<Int>, shipX: Int): String =
+private fun render(rocks: List<Int>, trail: List<Int>, shipX: Int): String =
     rocks.withIndex().joinToString("\n") { (row, rock) ->
         val line = CharArray(COLUMNS) { WATER }
         if (rock in 0 until COLUMNS) line[rock] = ROCK
-        if (row == SHIP_ROW) line[shipX] = SHIP
+        val ship = if (row == SHIP_ROW) shipX else trail.getOrElse(row) { NONE }
+        if (ship in 0 until COLUMNS) line[ship] = SHIP
         String(line).trimEnd()
     }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -1,0 +1,177 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import app.jigglass.glass.GlassClient
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+private const val COLUMNS = 20
+private const val ROWS = 8
+private const val SHIP_ROW = 1
+private const val TICK_MS = 200L
+
+// 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
+private const val EDGE_YAW_DEGREES = 180f
+
+private const val SHIP = 'O'
+private const val ROCK = '*'
+
+/**
+ * IchigoJam のかわくだりを 6DoF で遊ぶ画面。
+ * 自機はヨー、画面は汎用テキスト表示ページへ毎ティック送り直す。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
+    val scope = rememberCoroutineScope()
+    val commandManager = remember(client) { client.createCommandManager() }
+    val yaw = remember { MutableStateFlow<Float?>(null) }
+
+    var playing by remember { mutableStateOf(false) }
+    var score by remember { mutableStateOf(0) }
+    var gameOver by remember { mutableStateOf(false) }
+    var field by remember { mutableStateOf("") }
+
+    DisposableEffect(commandManager) {
+        val job: Job = scope.launch {
+            commandManager.imuData.collect { yaw.value = it.yawDegrees }
+        }
+        commandManager.startImuData()
+        onDispose {
+            job.cancel()
+            commandManager.stopImuData()
+            commandManager.enterHomePage()
+        }
+    }
+
+    LaunchedEffect(playing) {
+        if (!playing) return@LaunchedEffect
+
+        // 遊び始めた向きを中央にする。ヨーは磁力計が無くて絶対値が使えない
+        val centerYaw = yaw.filterNotNull().first()
+        val rocks = ArrayDeque(List(ROWS) { NO_ROCK })
+        score = 0
+        gameOver = false
+        commandManager.enterEmptyScreenPage()
+
+        while (isActive) {
+            val shipX = shipColumn(yaw.value ?: centerYaw, centerYaw)
+            rocks.removeFirst()
+            rocks.addLast(Random.nextInt(COLUMNS))
+
+            if (rocks.elementAt(SHIP_ROW) == shipX) {
+                gameOver = true
+                playing = false
+                field = render(rocks, shipX)
+                commandManager.sendEmptyScreenContent("GAME OVER\nSCORE $score")
+                return@LaunchedEffect
+            }
+
+            score++
+            field = render(rocks, shipX)
+            commandManager.sendEmptyScreenContent(field)
+            delay(TICK_MS)
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("かわくだり") }) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "首を回して岩「$ROCK」をよける。まっすぐ前が中央で、" +
+                    "${EDGE_YAW_DEGREES.toInt()}度回すと端に着く。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = { playing = !playing },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (playing) "やめる" else if (gameOver) "もう一度" else "はじめる")
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                if (gameOver) "GAME OVER / SCORE $score" else "SCORE $score",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            Text(
+                field.ifEmpty { "まだ始まっていない" },
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = FontFamily.Monospace,
+            )
+
+            Spacer(Modifier.height(24.dp))
+            OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
+                Text("戻る")
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+private const val NO_ROCK = -1
+
+private fun shipColumn(currentYaw: Float, centerYaw: Float): Int {
+    val half = (COLUMNS - 1) / 2f
+    val offset = normalizeDegrees(currentYaw - centerYaw) / EDGE_YAW_DEGREES * half
+    return (half + offset).roundToInt().coerceIn(0, COLUMNS - 1)
+}
+
+private fun normalizeDegrees(degrees: Float): Float {
+    var value = degrees
+    while (value > 180f) value -= 360f
+    while (value < -180f) value += 360f
+    return value
+}
+
+private fun render(rocks: List<Int>, shipX: Int): String =
+    rocks.withIndex().joinToString("\n") { (row, rock) ->
+        val line = CharArray(COLUMNS) { ' ' }
+        if (rock in 0 until COLUMNS) line[rock] = ROCK
+        if (row == SHIP_ROW) line[shipX] = SHIP
+        String(line).trimEnd()
+    }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -95,13 +95,14 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
         while (isActive) {
             val shipX = shipColumn(yaw.value ?: centerYaw, centerYaw)
-            rocks.removeFirst()
-            rocks.addLast(Random.nextInt(COLUMNS))
+            // 1つ下の岩は次のスクロールで自機に重なる。ぶつかる直前の盤面を見せたいので先に判定する
+            val hit = rocks.elementAt(SHIP_ROW + 1) == shipX
 
-            if (rocks.elementAt(SHIP_ROW) == shipX) {
+            field = render(rocks, trail, shipX, score)
+            commandManager.sendEmptyScreenContent(field)
+
+            if (hit) {
                 gameOver = true
-                field = render(rocks, trail, shipX, score)
-                commandManager.sendEmptyScreenContent(field)
                 delay(RESULT_DELAY_MS)
                 commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
                 // playing を倒すとこのコルーチンが消えるので、送り終えてから
@@ -110,8 +111,8 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
             }
 
             score++
-            field = render(rocks, trail, shipX, score)
-            commandManager.sendEmptyScreenContent(field)
+            rocks.removeFirst()
+            rocks.addLast(Random.nextInt(COLUMNS))
             trail.removeFirst()
             trail.addLast(shipX)
             delay(TICK_MS)

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -44,7 +44,7 @@ private const val SHIP_ROW = 1
 private const val TICK_MS = 400L
 
 // 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
-private const val EDGE_YAW_DEGREES = 180f
+private const val EDGE_YAW_DEGREES = 90f
 
 private const val SHIP = 'O'
 private const val ROCK = '*'

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -41,7 +41,7 @@ import kotlin.random.Random
 private const val COLUMNS = 20
 private const val ROWS = 8
 private const val SHIP_ROW = 1
-private const val TICK_MS = 200L
+private const val TICK_MS = 400L
 
 // 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
 private const val EDGE_YAW_DEGREES = 180f

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -41,13 +41,14 @@ import kotlin.random.Random
 private const val COLUMNS = 20
 private const val ROWS = 8
 private const val SHIP_ROW = 1
-private const val TICK_MS = 400L
+private const val TICK_MS = 500L
 
 // 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
 private const val EDGE_YAW_DEGREES = 90f
 
-private const val SHIP = 'O'
-private const val ROCK = '*'
+private const val SHIP = 'Ｏ'
+private const val ROCK = '＊'
+private const val WATER = '\u3000'
 
 /**
  * IchigoJam のかわくだりを 6DoF で遊ぶ画面。
@@ -96,7 +97,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
                 gameOver = true
                 playing = false
                 field = render(rocks, shipX)
-                commandManager.sendEmptyScreenContent("GAME OVER\nSCORE $score")
+                commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
                 return@LaunchedEffect
             }
 
@@ -157,9 +158,13 @@ private const val NO_ROCK = -1
 
 private fun shipColumn(currentYaw: Float, centerYaw: Float): Int {
     val half = (COLUMNS - 1) / 2f
-    val offset = normalizeDegrees(currentYaw - centerYaw) / EDGE_YAW_DEGREES * half
+    // ヨーは右を向くと減る向きなので反転させる
+    val offset = -normalizeDegrees(currentYaw - centerYaw) / EDGE_YAW_DEGREES * half
     return (half + offset).roundToInt().coerceIn(0, COLUMNS - 1)
 }
+
+private fun toFullWidth(value: Int): String =
+    value.toString().map { (it.code + 0xFEE0).toChar() }.joinToString("")
 
 private fun normalizeDegrees(degrees: Float): Float {
     var value = degrees
@@ -170,7 +175,7 @@ private fun normalizeDegrees(degrees: Float): Float {
 
 private fun render(rocks: List<Int>, shipX: Int): String =
     rocks.withIndex().joinToString("\n") { (row, rock) ->
-        val line = CharArray(COLUMNS) { ' ' }
+        val line = CharArray(COLUMNS) { WATER }
         if (rock in 0 until COLUMNS) line[rock] = ROCK
         if (row == SHIP_ROW) line[shipX] = SHIP
         String(line).trimEnd()

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -27,8 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import app.jigglass.glass.GestureType
 import app.jigglass.glass.GlassClient
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -40,7 +40,6 @@ import kotlin.random.Random
 
 private const val COLUMNS = 20
 private const val ROWS = 8
-private const val ROCKS_PER_ROW = 2
 private const val SHIP_ROW = 3
 private const val TICK_MS = 500L
 
@@ -54,6 +53,13 @@ private const val SHIP = 'Ｏ'
 private const val ROCK = '＊'
 private const val WATER = '\u3000'
 
+private const val WAITING_TEXT = "ＫＡＷＡＫＵＤＡＲＩ\nタップ　ノーマル\n長押し　ハード"
+
+private enum class Mode(val label: String, val rocksPerRow: Int) {
+    NORMAL("ノーマル", 1),
+    HARD("ハード", 2),
+}
+
 /**
  * IchigoJam のかわくだりを 6DoF で遊ぶ画面。
  * 自機はヨー、画面は汎用テキスト表示ページへ毎ティック送り直す。
@@ -66,32 +72,48 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
     val yaw = remember { MutableStateFlow<Float?>(null) }
 
     var playing by remember { mutableStateOf(false) }
+    var mode by remember { mutableStateOf(Mode.NORMAL) }
     var score by remember { mutableStateOf(0) }
     var gameOver by remember { mutableStateOf(false) }
     var field by remember { mutableStateOf("") }
 
     DisposableEffect(commandManager) {
-        val job: Job = scope.launch {
-            commandManager.imuData.collect { yaw.value = it.yawDegrees }
-        }
+        val jobs = listOf(
+            scope.launch {
+                commandManager.imuData.collect { yaw.value = it.yawDegrees }
+            },
+            scope.launch {
+                commandManager.gestureEvents.collect { gesture ->
+                    if (playing) return@collect
+                    when (gesture) {
+                        GestureType.SINGLE_TAP -> mode = Mode.NORMAL
+                        GestureType.HOLD -> mode = Mode.HARD
+                        else -> return@collect
+                    }
+                    playing = true
+                }
+            },
+        )
         commandManager.startImuData()
+        commandManager.enterEmptyScreenPage()
+        commandManager.sendEmptyScreenContent(WAITING_TEXT)
         onDispose {
-            job.cancel()
+            jobs.forEach { it.cancel() }
             commandManager.stopImuData()
             commandManager.enterHomePage()
         }
     }
 
-    LaunchedEffect(playing) {
+    LaunchedEffect(playing, mode) {
         if (!playing) return@LaunchedEffect
 
+        score = 0
+        gameOver = false
         // 遊び始めた向きを中央にする。ヨーは磁力計が無くて絶対値が使えない
         val centerYaw = yaw.filterNotNull().first()
         val rocks = ArrayDeque(List(ROWS) { emptyList<Int>() })
         // 自機より上の行に残る軌跡。岩と一緒に上へ流れる
         val trail = ArrayDeque(List(SHIP_ROW) { NONE })
-        score = 0
-        gameOver = false
         commandManager.enterEmptyScreenPage()
 
         while (isActive) {
@@ -113,7 +135,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
             score++
             rocks.removeFirst()
-            rocks.addLast(List(ROCKS_PER_ROW) { Random.nextInt(COLUMNS) })
+            rocks.addLast(List(mode.rocksPerRow) { Random.nextInt(COLUMNS) })
             trail.removeFirst()
             trail.addLast(shipX)
             delay(TICK_MS)
@@ -132,20 +154,36 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
         ) {
             Text(
                 "首を回して岩「$ROCK」をよける。まっすぐ前が中央で、" +
-                    "${EDGE_YAW_DEGREES.toInt()}度回すと端に着く。",
+                    "${EDGE_YAW_DEGREES.toInt()}度回すと端に着く。" +
+                    "グラスのタップでノーマル、長押しでハードが始まる。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
 
-            Button(
-                onClick = { playing = !playing },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(if (gameOver) "もう一度" else if (playing) "やめる" else "はじめる")
+            if (playing) {
+                Button(
+                    onClick = { playing = false },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("やめる")
+                }
+            } else {
+                Mode.entries.forEach { entry ->
+                    Button(
+                        onClick = {
+                            mode = entry
+                            playing = true
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("${entry.label}ではじめる")
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
             }
             Spacer(Modifier.height(8.dp))
             Text(
-                if (gameOver) "GAME OVER / SCORE $score" else "SCORE $score",
+                if (gameOver) "GAME OVER / ${mode.label} / SCORE $score" else "${mode.label} / SCORE $score",
                 style = MaterialTheme.typography.bodyMedium,
             )
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -129,7 +129,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
                 gameOver = true
                 delay(RESULT_DELAY_MS)
                 commandManager.sendEmptyScreenContent(
-                    "ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}\n" + GUIDE_TEXT,
+                    "ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}\n\n" + GUIDE_TEXT,
                 )
                 // playing を倒すとこのコルーチンが消えるので、送り終えてから
                 playing = false

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -43,6 +43,9 @@ private const val ROWS = 8
 private const val SHIP_ROW = 3
 private const val TICK_MS = 500L
 
+// ぶつかった盤面を見せてからリザルトへ切り替えるまで
+private const val RESULT_DELAY_MS = 1000L
+
 // 端まで首を回す量。IchigoJam の左右キーの代わりにヨーで動かす
 private const val EDGE_YAW_DEGREES = 90f
 
@@ -97,9 +100,12 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
             if (rocks.elementAt(SHIP_ROW) == shipX) {
                 gameOver = true
-                playing = false
                 field = render(rocks, trail, shipX, score)
+                commandManager.sendEmptyScreenContent(field)
+                delay(RESULT_DELAY_MS)
                 commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
+                // playing を倒すとこのコルーチンが消えるので、送り終えてから
+                playing = false
                 return@LaunchedEffect
             }
 
@@ -133,7 +139,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
                 onClick = { playing = !playing },
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(if (playing) "やめる" else if (gameOver) "もう一度" else "はじめる")
+                Text(if (gameOver) "もう一度" else if (playing) "やめる" else "はじめる")
             }
             Spacer(Modifier.height(8.dp))
             Text(

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -219,7 +219,7 @@ private fun shipColumn(currentYaw: Float, centerYaw: Float): Int {
 private fun toFullWidth(value: Int): String =
     value.toString().map { (it.code + 0xFEE0).toChar() }.joinToString("")
 
-private fun normalizeDegrees(degrees: Float): Float {
+internal fun normalizeDegrees(degrees: Float): Float {
     var value = degrees
     while (value > 180f) value -= 360f
     while (value < -180f) value += 360f

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -53,7 +53,8 @@ private const val SHIP = 'Ｏ'
 private const val ROCK = '＊'
 private const val WATER = '\u3000'
 
-private const val WAITING_TEXT = "ＫＡＷＡＫＵＤＡＲＩ\nタップ　ノーマル\n長押し　ハード"
+private const val GUIDE_TEXT = "ＴＡＰ：ＮＯＲＭＡＬ\nＨＯＬＤ：ＨＡＲＤ"
+private const val WAITING_TEXT = "ＫＡＷＡＫＵＤＡＲＩ\n" + GUIDE_TEXT
 
 private enum class Mode(val label: String, val rocksPerRow: Int) {
     NORMAL("ノーマル", 1),
@@ -127,7 +128,9 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
             if (hit) {
                 gameOver = true
                 delay(RESULT_DELAY_MS)
-                commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
+                commandManager.sendEmptyScreenContent(
+                    "ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}\n" + GUIDE_TEXT,
+                )
                 // playing を倒すとこのコルーチンが消えるので、送り終えてから
                 playing = false
                 return@LaunchedEffect

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -40,6 +40,7 @@ import kotlin.random.Random
 
 private const val COLUMNS = 20
 private const val ROWS = 8
+private const val ROCKS_PER_ROW = 2
 private const val SHIP_ROW = 3
 private const val TICK_MS = 500L
 
@@ -86,7 +87,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
         // 遊び始めた向きを中央にする。ヨーは磁力計が無くて絶対値が使えない
         val centerYaw = yaw.filterNotNull().first()
-        val rocks = ArrayDeque(List(ROWS) { NONE })
+        val rocks = ArrayDeque(List(ROWS) { emptyList<Int>() })
         // 自機より上の行に残る軌跡。岩と一緒に上へ流れる
         val trail = ArrayDeque(List(SHIP_ROW) { NONE })
         score = 0
@@ -96,7 +97,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
         while (isActive) {
             val shipX = shipColumn(yaw.value ?: centerYaw, centerYaw)
             // 1つ下の岩は次のスクロールで自機に重なる。ぶつかる直前の盤面を見せたいので先に判定する
-            val hit = rocks.elementAt(SHIP_ROW + 1) == shipX
+            val hit = shipX in rocks.elementAt(SHIP_ROW + 1)
 
             field = render(rocks, trail, shipX, score)
             commandManager.sendEmptyScreenContent(field)
@@ -112,7 +113,7 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
 
             score++
             rocks.removeFirst()
-            rocks.addLast(Random.nextInt(COLUMNS))
+            rocks.addLast(List(ROCKS_PER_ROW) { Random.nextInt(COLUMNS) })
             trail.removeFirst()
             trail.addLast(shipX)
             delay(TICK_MS)
@@ -184,10 +185,10 @@ private fun normalizeDegrees(degrees: Float): Float {
     return value
 }
 
-private fun render(rocks: List<Int>, trail: List<Int>, shipX: Int, score: Int): String =
-    rocks.withIndex().joinToString("\n") { (row, rock) ->
+private fun render(rocks: List<List<Int>>, trail: List<Int>, shipX: Int, score: Int): String =
+    rocks.withIndex().joinToString("\n") { (row, rocksInRow) ->
         val line = CharArray(COLUMNS) { WATER }
-        if (rock in 0 until COLUMNS) line[rock] = ROCK
+        rocksInRow.forEach { line[it] = ROCK }
         val ship = if (row == SHIP_ROW) shipX else trail.getOrElse(row) { NONE }
         if (ship in 0 until COLUMNS) line[ship] = SHIP
         // 最上段は上へ流れて消える行なので、岩に重ねてスコアを置く

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/KawakudariScreen.kt
@@ -98,13 +98,13 @@ fun KawakudariScreen(client: GlassClient, onBack: () -> Unit) {
             if (rocks.elementAt(SHIP_ROW) == shipX) {
                 gameOver = true
                 playing = false
-                field = render(rocks, trail, shipX)
+                field = render(rocks, trail, shipX, score)
                 commandManager.sendEmptyScreenContent("ＧＡＭＥ　ＯＶＥＲ\nＳＣＯＲＥ${toFullWidth(score)}")
                 return@LaunchedEffect
             }
 
             score++
-            field = render(rocks, trail, shipX)
+            field = render(rocks, trail, shipX, score)
             commandManager.sendEmptyScreenContent(field)
             trail.removeFirst()
             trail.addLast(shipX)
@@ -177,11 +177,13 @@ private fun normalizeDegrees(degrees: Float): Float {
     return value
 }
 
-private fun render(rocks: List<Int>, trail: List<Int>, shipX: Int): String =
+private fun render(rocks: List<Int>, trail: List<Int>, shipX: Int, score: Int): String =
     rocks.withIndex().joinToString("\n") { (row, rock) ->
         val line = CharArray(COLUMNS) { WATER }
         if (rock in 0 until COLUMNS) line[rock] = ROCK
         val ship = if (row == SHIP_ROW) shipX else trail.getOrElse(row) { NONE }
         if (ship in 0 until COLUMNS) line[ship] = SHIP
+        // 最上段は上へ流れて消える行なので、岩に重ねてスコアを置く
+        if (row == 0) toFullWidth(score).forEachIndexed { i, digit -> line[i] = digit }
         String(line).trimEnd()
     }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -46,30 +46,40 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-/** アイコンの一辺。96角3枚ならグラスの画像バッファに余裕がある */
+/** アイコンの一辺。96角6枚でもグラスの画像バッファに収まる */
 private const val ICON_SIZE = 96
 private const val ICON_GAP = 48
-private const val ICON_Y = 40
+private const val ICON_ROW_GAP = 16
+private const val ICON_TOP_Y = 16
 
-/** 説明テキストの矩形。アイコンの下に置く */
+/** 3列2段。画像は id 0..7 なので6枚まで置ける */
+private const val GRID_COLUMNS = 3
+private const val GRID_ROWS = 2
+
+/** 説明テキストの矩形。アイコンの下の余りに置く */
 private const val TEXT_X = 48
-private const val TEXT_Y = 184
 private const val TEXT_WIDTH = 480
-private const val TEXT_HEIGHT = 140
+private const val TEXT_HEIGHT = 112
 
 private const val CANVAS_WIDTH = 576
 
-/** 隣のアイコンへ移るまでの振り向き量 */
+/** 隣の列へ移るまでの振り向き量 */
 private const val STEP_DEGREES = 20f
 
-/** ヨーを見に行く間隔。変わったときだけ送るので短くても送信は増えない */
+/** 下の段へ移るまでのうなずき量。ピッチは上向きが負 */
+private const val ROW_STEP_DEGREES = 15f
+
+/** ヨーとピッチを見に行く間隔。変わったときだけ送るので短くても送信は増えない */
 private const val CURSOR_POLL_MS = 100L
 
 /** ランチャーに並べる機能。アイコンは絵柄の代わりに漢字1字で描く */
 enum class LauncherItem(val label: String, val glyph: String, val description: String) {
-    KAWAKUDARI("かわくだり", "川", "首を振って岩をよけるゲーム。タップでノーマル、長押しでハードが始まる。"),
+    KAWAKUDARI("かわくだり", "川", "首を振って岩をよけるゲーム。タップでノーマル、長押しでハード。"),
     TELEPROMPTER("テレプロンプター", "読", "原稿を送って、行を進めながら読み上げる。"),
     TRANSLATE("翻訳", "訳", "話した言葉をその場で訳して出す。"),
+    AI_CHAT("AI アシスタント", "問", "聞いたことに答えを返す。"),
+    IMAGE("画像を送る", "絵", "選んだ写真をグレースケールにして出す。"),
+    IMU("6DoF を見る", "角", "加速度・角速度・ピッチ・ヨーの生の値を並べる。"),
 }
 
 /**
@@ -81,7 +91,7 @@ enum class LauncherItem(val label: String, val glyph: String, val description: S
 fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
     val commandManager = remember(client) { client.createCommandManager() }
-    val yaw = remember { MutableStateFlow<Float?>(null) }
+    val imu = remember { MutableStateFlow<CommandManager.ImuData?>(null) }
 
     val items = remember { LauncherItem.entries }
     // フォーカスの有無で差し替えるので、2状態とも先に作っておく
@@ -92,7 +102,7 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
     DisposableEffect(commandManager) {
         val jobs = listOf(
             scope.launch {
-                commandManager.imuData.collect { yaw.value = it.yawDegrees }
+                commandManager.imuData.collect { imu.value = it }
             },
             scope.launch {
                 commandManager.gestureEvents.collect { gesture ->
@@ -109,15 +119,15 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
     }
 
     LaunchedEffect(Unit) {
-        // 画面に入った向きを中央のアイコンに合わせる
-        val centerYaw = yaw.filterNotNull().first()
+        // 画面に入った向きを上段の中央に合わせる
+        val center = imu.filterNotNull().first()
 
         commandManager.sendCanvas(listOf(descriptionElement(items[focused])))
-        items.forEachIndexed { index, _ ->
+        items.indices.forEach { index ->
             commandManager.sendCanvasImage(
                 id = index,
-                x = iconX(index, items.size),
-                y = ICON_Y,
+                x = iconX(index),
+                y = iconY(index),
                 width = ICON_SIZE,
                 height = ICON_SIZE,
                 grayscale = icons[index].let { if (index == focused) it.second else it.first }.pixels,
@@ -126,23 +136,23 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
 
         while (isActive) {
             delay(CURSOR_POLL_MS)
-            val next = cursorIndex(yaw.value ?: centerYaw, centerYaw, items.size)
+            val next = cursorIndex(imu.value ?: center, center, items.size)
             if (next == focused) continue
 
             val previous = focused
             focused = next
             commandManager.sendCanvasImage(
                 id = previous,
-                x = iconX(previous, items.size),
-                y = ICON_Y,
+                x = iconX(previous),
+                y = iconY(previous),
                 width = ICON_SIZE,
                 height = ICON_SIZE,
                 grayscale = icons[previous].first.pixels,
             )
             commandManager.sendCanvasImage(
                 id = next,
-                x = iconX(next, items.size),
-                y = ICON_Y,
+                x = iconX(next),
+                y = iconY(next),
                 width = ICON_SIZE,
                 height = ICON_SIZE,
                 grayscale = icons[next].second.pixels,
@@ -163,26 +173,32 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
         ) {
             Text(
                 "首を振ってカーソルを動かし、グラスのシングルタップで選ぶ。" +
-                    "隣に移るまで${STEP_DEGREES.toInt()}度。",
+                    "隣の列まで${STEP_DEGREES.toInt()}度、下の段までうなずき${ROW_STEP_DEGREES.toInt()}度。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                items.forEachIndexed { index, item ->
-                    val icon = icons[index].let { if (index == focused) it.second else it.first }
-                    Image(
-                        bitmap = icon.toBitmap().asImageBitmap(),
-                        contentDescription = item.label,
-                        modifier = Modifier.size(72.dp),
-                    )
+            (0 until GRID_ROWS).forEach { row ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    (0 until GRID_COLUMNS).forEach { column ->
+                        val index = row * GRID_COLUMNS + column
+                        val item = items.getOrNull(index) ?: return@forEach
+                        val icon = icons[index].let { if (index == focused) it.second else it.first }
+                        Image(
+                            bitmap = icon.toBitmap().asImageBitmap(),
+                            contentDescription = item.label,
+                            modifier = Modifier.size(72.dp),
+                        )
+                    }
                 }
+                Spacer(Modifier.height(8.dp))
             }
-            Spacer(Modifier.height(16.dp))
+
+            Spacer(Modifier.height(8.dp))
             Text(items[focused].label, style = MaterialTheme.typography.titleMedium)
             Text(items[focused].description, style = MaterialTheme.typography.bodyMedium)
 
@@ -195,10 +211,7 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
                 Text("${items[focused].label}をひらく")
             }
             Spacer(Modifier.height(8.dp))
-            OutlinedButton(
-                onClick = onBack,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
+            OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
                 Text("戻る")
             }
             Spacer(Modifier.height(24.dp))
@@ -209,25 +222,30 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
 private fun descriptionElement(item: LauncherItem) = CommandManager.CanvasElement(
     id = 0,
     x = TEXT_X,
-    y = TEXT_Y,
+    y = ICON_TOP_Y + GRID_ROWS * (ICON_SIZE + ICON_ROW_GAP),
     width = TEXT_WIDTH,
     height = TEXT_HEIGHT,
     text = "${item.label}\n${item.description}",
 )
 
-private fun iconX(index: Int, count: Int): Int {
-    val row = count * ICON_SIZE + (count - 1) * ICON_GAP
-    return (CANVAS_WIDTH - row) / 2 + index * (ICON_SIZE + ICON_GAP)
+private fun iconX(index: Int): Int {
+    val row = GRID_COLUMNS * ICON_SIZE + (GRID_COLUMNS - 1) * ICON_GAP
+    return (CANVAS_WIDTH - row) / 2 + (index % GRID_COLUMNS) * (ICON_SIZE + ICON_GAP)
 }
 
-private fun cursorIndex(currentYaw: Float, centerYaw: Float, count: Int): Int {
-    val steps = (-normalizeDegrees(currentYaw - centerYaw) / STEP_DEGREES).roundToInt()
-    return (count / 2 + steps).coerceIn(0, count - 1)
+private fun iconY(index: Int): Int =
+    ICON_TOP_Y + (index / GRID_COLUMNS) * (ICON_SIZE + ICON_ROW_GAP)
+
+private fun cursorIndex(current: CommandManager.ImuData, center: CommandManager.ImuData, count: Int): Int {
+    val steps = (-normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES).roundToInt()
+    val column = (GRID_COLUMNS / 2 + steps).coerceIn(0, GRID_COLUMNS - 1)
+    val row = if (current.pitchDegrees - center.pitchDegrees > ROW_STEP_DEGREES) 1 else 0
+    return (row * GRID_COLUMNS + column).coerceAtMost(count - 1)
 }
 
 /**
  * アイコンを2値で描く。グラスは3bitに量子化するので、中間の階調は残さない。
- * フォーカスは白地に黒抜きの太枠で、絵柄そのものに含める。
+ * フォーカスは枠の太さと白黒反転で、絵柄そのものに含める。
  */
 private fun iconImage(glyph: String, focused: Boolean, size: Int = ICON_SIZE): GrayscaleImage {
     val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -238,7 +238,8 @@ private fun iconY(index: Int): Int =
 
 private fun cursorIndex(current: CommandManager.ImuData, center: CommandManager.ImuData, count: Int): Int {
     val steps = (-normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES).roundToInt()
-    val column = (GRID_COLUMNS / 2 + steps).coerceIn(0, GRID_COLUMNS - 1)
+    // 端で止めずに反対側へ回り込む。mod は負でも 0..GRID_COLUMNS-1 を返す
+    val column = (GRID_COLUMNS / 2 + steps).mod(GRID_COLUMNS)
     val row = if (current.pitchDegrees - center.pitchDegrees > ROW_STEP_DEGREES) 1 else 0
     return (row * GRID_COLUMNS + column).coerceAtMost(count - 1)
 }

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -64,11 +64,20 @@ private const val TEXT_HEIGHT = 112
 
 private const val CANVAS_WIDTH = 576
 
+/** アイコンを横に並べたときの左端 */
+private const val GRID_LEFT = (CANVAS_WIDTH - (GRID_COLUMNS * ICON_SIZE + (GRID_COLUMNS - 1) * ICON_GAP)) / 2
+
 /** 隣の列へ移るまでの振り向き量 */
 private const val STEP_DEGREES = 20f
 
 /** 上の段へ移るまでの見上げ量。ピッチは上向きが負 */
 private const val ROW_STEP_DEGREES = 15f
+
+/** 首の向きそのものを差すポインター。テキストは画像の手前に描かれる */
+private const val POINTER_TEXT = "・"
+private const val POINTER_ELEMENT_ID = 1
+private const val POINTER_SIZE = 32
+private const val POINTER_MOVE_PX = 8
 
 /** 境目での行き来を防ぐ遊び。列はセル幅に対する割合、段は度 */
 private const val COLUMN_HYSTERESIS = 0.25f
@@ -132,8 +141,14 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
 
         // 回り込んでも連続させるため、列は範囲を切らないセル番号で持つ
         var columnCell = GRID_COLUMNS / 2
+        var pointerX = pointerX(columnCell.toFloat())
 
-        commandManager.sendCanvas(listOf(descriptionElement(items[focused])))
+        commandManager.sendCanvas(
+            listOf(
+                descriptionElement(items[focused]),
+                pointerElement(pointerX, focused / GRID_COLUMNS),
+            ),
+        )
         items.indices.forEach { index ->
             commandManager.sendCanvasImage(
                 id = index,
@@ -151,10 +166,19 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
             columnCell = columnCellFor(data, center, columnCell)
             val row = rowFor(data, center, focused / GRID_COLUMNS)
             val next = row * GRID_COLUMNS + columnCell.mod(GRID_COLUMNS)
-            if (next == focused) continue
+
+            // ポインターは離散したフォーカスではなく、首の向きのまま動かす
+            val nextPointerX = pointerX(columnPosition(data, center))
+            if (next == focused) {
+                if (abs(nextPointerX - pointerX) < POINTER_MOVE_PX) continue
+                pointerX = nextPointerX
+                commandManager.sendCanvasElements(listOf(pointerElement(pointerX, row)))
+                continue
+            }
 
             val previous = focused
             focused = next
+            pointerX = nextPointerX
             commandManager.sendCanvasImage(
                 id = previous,
                 x = iconX(previous),
@@ -171,7 +195,12 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
                 height = ICON_SIZE,
                 grayscale = icons[next].second.pixels,
             )
-            commandManager.sendCanvasElements(listOf(descriptionElement(items[next])))
+            commandManager.sendCanvasElements(
+                listOf(
+                    descriptionElement(items[next]),
+                    pointerElement(pointerX, row),
+                ),
+            )
         }
     }
 
@@ -242,23 +271,38 @@ private fun descriptionElement(item: LauncherItem) = CommandManager.CanvasElemen
     text = "${item.label}\n${item.description}",
 )
 
-private fun iconX(index: Int): Int {
-    val row = GRID_COLUMNS * ICON_SIZE + (GRID_COLUMNS - 1) * ICON_GAP
-    return (CANVAS_WIDTH - row) / 2 + (index % GRID_COLUMNS) * (ICON_SIZE + ICON_GAP)
-}
+private fun iconX(index: Int): Int = GRID_LEFT + (index % GRID_COLUMNS) * (ICON_SIZE + ICON_GAP)
 
 private fun iconY(index: Int): Int =
     ICON_TOP_Y + (index / GRID_COLUMNS) * (ICON_SIZE + ICON_ROW_GAP)
+
+/** 首の向きをセル単位の連続値にする。回り込むぶん範囲は切らない */
+private fun columnPosition(current: CommandManager.ImuData, center: CommandManager.ImuData): Float =
+    GRID_COLUMNS / 2f - normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES
 
 private fun columnCellFor(
     current: CommandManager.ImuData,
     center: CommandManager.ImuData,
     currentCell: Int,
 ): Int {
-    val position = GRID_COLUMNS / 2f - normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES
+    val position = columnPosition(current, center)
     // 半セルを少し越えるまで居座らせる。境目で振れても隣に落ちない
     return if (abs(position - currentCell) > 0.5f + COLUMN_HYSTERESIS) position.roundToInt() else currentCell
 }
+
+private fun pointerX(position: Float): Int {
+    val cell = position.mod(GRID_COLUMNS.toFloat())
+    return (GRID_LEFT + cell * (ICON_SIZE + ICON_GAP) + (ICON_SIZE - POINTER_SIZE) / 2).roundToInt()
+}
+
+private fun pointerElement(x: Int, row: Int) = CommandManager.CanvasElement(
+    id = POINTER_ELEMENT_ID,
+    x = x,
+    y = ICON_TOP_Y + row * (ICON_SIZE + ICON_ROW_GAP),
+    width = POINTER_SIZE,
+    height = POINTER_SIZE,
+    text = POINTER_TEXT,
+)
 
 private fun rowFor(current: CommandManager.ImuData, center: CommandManager.ImuData, currentRow: Int): Int {
     val delta = current.pitchDegrees - center.pitchDegrees

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -66,8 +66,11 @@ private const val CANVAS_WIDTH = 576
 /** 隣の列へ移るまでの振り向き量 */
 private const val STEP_DEGREES = 20f
 
-/** 下の段へ移るまでのうなずき量。ピッチは上向きが負 */
+/** 上の段へ移るまでの見上げ量。ピッチは上向きが負 */
 private const val ROW_STEP_DEGREES = 15f
+
+/** 起点は下段の中央。楽な姿勢のまま選べる位置に置く */
+private const val DEFAULT_INDEX = (GRID_ROWS - 1) * GRID_COLUMNS + GRID_COLUMNS / 2
 
 /** ヨーとピッチを見に行く間隔。変わったときだけ送るので短くても送信は増えない */
 private const val CURSOR_POLL_MS = 100L
@@ -97,7 +100,7 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
     // フォーカスの有無で差し替えるので、2状態とも先に作っておく
     val icons = remember { items.map { iconImage(it.glyph, false) to iconImage(it.glyph, true) } }
 
-    var focused by remember { mutableStateOf(0) }
+    var focused by remember { mutableStateOf(DEFAULT_INDEX) }
 
     DisposableEffect(commandManager) {
         val jobs = listOf(
@@ -119,7 +122,7 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
     }
 
     LaunchedEffect(Unit) {
-        // 画面に入った向きを上段の中央に合わせる
+        // 画面に入った向きを下段の中央に合わせる
         val center = imu.filterNotNull().first()
 
         commandManager.sendCanvas(listOf(descriptionElement(items[focused])))
@@ -173,7 +176,7 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
         ) {
             Text(
                 "首を振ってカーソルを動かし、グラスのシングルタップで選ぶ。" +
-                    "隣の列まで${STEP_DEGREES.toInt()}度、下の段までうなずき${ROW_STEP_DEGREES.toInt()}度。",
+                    "隣の列まで${STEP_DEGREES.toInt()}度、上の段は${ROW_STEP_DEGREES.toInt()}度見上げる。",
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(16.dp))
@@ -240,7 +243,7 @@ private fun cursorIndex(current: CommandManager.ImuData, center: CommandManager.
     val steps = (-normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES).roundToInt()
     // 端で止めずに反対側へ回り込む。mod は負でも 0..GRID_COLUMNS-1 を返す
     val column = (GRID_COLUMNS / 2 + steps).mod(GRID_COLUMNS)
-    val row = if (current.pitchDegrees - center.pitchDegrees > ROW_STEP_DEGREES) 1 else 0
+    val row = if (current.pitchDegrees - center.pitchDegrees < -ROW_STEP_DEGREES) 0 else GRID_ROWS - 1
     return (row * GRID_COLUMNS + column).coerceAtMost(count - 1)
 }
 

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /** アイコンの一辺。96角6枚でもグラスの画像バッファに収まる */
@@ -68,6 +69,10 @@ private const val STEP_DEGREES = 20f
 
 /** 上の段へ移るまでの見上げ量。ピッチは上向きが負 */
 private const val ROW_STEP_DEGREES = 15f
+
+/** 境目での行き来を防ぐ遊び。列はセル幅に対する割合、段は度 */
+private const val COLUMN_HYSTERESIS = 0.25f
+private const val ROW_HYSTERESIS_DEGREES = 7f
 
 /** 起点は下段の中央。楽な姿勢のまま選べる位置に置く */
 private const val DEFAULT_INDEX = (GRID_ROWS - 1) * GRID_COLUMNS + GRID_COLUMNS / 2
@@ -125,6 +130,9 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
         // 画面に入った向きを下段の中央に合わせる
         val center = imu.filterNotNull().first()
 
+        // 回り込んでも連続させるため、列は範囲を切らないセル番号で持つ
+        var columnCell = GRID_COLUMNS / 2
+
         commandManager.sendCanvas(listOf(descriptionElement(items[focused])))
         items.indices.forEach { index ->
             commandManager.sendCanvasImage(
@@ -139,7 +147,10 @@ fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack
 
         while (isActive) {
             delay(CURSOR_POLL_MS)
-            val next = cursorIndex(imu.value ?: center, center, items.size)
+            val data = imu.value ?: center
+            columnCell = columnCellFor(data, center, columnCell)
+            val row = rowFor(data, center, focused / GRID_COLUMNS)
+            val next = row * GRID_COLUMNS + columnCell.mod(GRID_COLUMNS)
             if (next == focused) continue
 
             val previous = focused
@@ -239,12 +250,23 @@ private fun iconX(index: Int): Int {
 private fun iconY(index: Int): Int =
     ICON_TOP_Y + (index / GRID_COLUMNS) * (ICON_SIZE + ICON_ROW_GAP)
 
-private fun cursorIndex(current: CommandManager.ImuData, center: CommandManager.ImuData, count: Int): Int {
-    val steps = (-normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES).roundToInt()
-    // 端で止めずに反対側へ回り込む。mod は負でも 0..GRID_COLUMNS-1 を返す
-    val column = (GRID_COLUMNS / 2 + steps).mod(GRID_COLUMNS)
-    val row = if (current.pitchDegrees - center.pitchDegrees < -ROW_STEP_DEGREES) 0 else GRID_ROWS - 1
-    return (row * GRID_COLUMNS + column).coerceAtMost(count - 1)
+private fun columnCellFor(
+    current: CommandManager.ImuData,
+    center: CommandManager.ImuData,
+    currentCell: Int,
+): Int {
+    val position = GRID_COLUMNS / 2f - normalizeDegrees(current.yawDegrees - center.yawDegrees) / STEP_DEGREES
+    // 半セルを少し越えるまで居座らせる。境目で振れても隣に落ちない
+    return if (abs(position - currentCell) > 0.5f + COLUMN_HYSTERESIS) position.roundToInt() else currentCell
+}
+
+private fun rowFor(current: CommandManager.ImuData, center: CommandManager.ImuData, currentRow: Int): Int {
+    val delta = current.pitchDegrees - center.pitchDegrees
+    return when {
+        delta < -ROW_STEP_DEGREES -> 0
+        delta > -ROW_STEP_DEGREES + ROW_HYSTERESIS_DEGREES -> GRID_ROWS - 1
+        else -> currentRow
+    }
 }
 
 /**

--- a/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
+++ b/samples/kmp/app/src/main/kotlin/jp/jig/glasses/sample/kmp/ui/LauncherScreen.kt
@@ -1,0 +1,262 @@
+package jp.jig.glasses.sample.kmp.ui
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
+import app.jigglass.glass.CommandManager
+import app.jigglass.glass.GestureType
+import app.jigglass.glass.GlassClient
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/** アイコンの一辺。96角3枚ならグラスの画像バッファに余裕がある */
+private const val ICON_SIZE = 96
+private const val ICON_GAP = 48
+private const val ICON_Y = 40
+
+/** 説明テキストの矩形。アイコンの下に置く */
+private const val TEXT_X = 48
+private const val TEXT_Y = 184
+private const val TEXT_WIDTH = 480
+private const val TEXT_HEIGHT = 140
+
+private const val CANVAS_WIDTH = 576
+
+/** 隣のアイコンへ移るまでの振り向き量 */
+private const val STEP_DEGREES = 20f
+
+/** ヨーを見に行く間隔。変わったときだけ送るので短くても送信は増えない */
+private const val CURSOR_POLL_MS = 100L
+
+/** ランチャーに並べる機能。アイコンは絵柄の代わりに漢字1字で描く */
+enum class LauncherItem(val label: String, val glyph: String, val description: String) {
+    KAWAKUDARI("かわくだり", "川", "首を振って岩をよけるゲーム。タップでノーマル、長押しでハードが始まる。"),
+    TELEPROMPTER("テレプロンプター", "読", "原稿を送って、行を進めながら読み上げる。"),
+    TRANSLATE("翻訳", "訳", "話した言葉をその場で訳して出す。"),
+}
+
+/**
+ * 6DoF でカーソルを動かすランチャー。
+ * アイコンはキャンバスの画像、説明はテキスト要素で、選択はグラスのシングルタップ。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LauncherScreen(client: GlassClient, onSelect: (LauncherItem) -> Unit, onBack: () -> Unit) {
+    val scope = rememberCoroutineScope()
+    val commandManager = remember(client) { client.createCommandManager() }
+    val yaw = remember { MutableStateFlow<Float?>(null) }
+
+    val items = remember { LauncherItem.entries }
+    // フォーカスの有無で差し替えるので、2状態とも先に作っておく
+    val icons = remember { items.map { iconImage(it.glyph, false) to iconImage(it.glyph, true) } }
+
+    var focused by remember { mutableStateOf(0) }
+
+    DisposableEffect(commandManager) {
+        val jobs = listOf(
+            scope.launch {
+                commandManager.imuData.collect { yaw.value = it.yawDegrees }
+            },
+            scope.launch {
+                commandManager.gestureEvents.collect { gesture ->
+                    if (gesture == GestureType.SINGLE_TAP) onSelect(items[focused])
+                }
+            },
+        )
+        commandManager.startImuData()
+        onDispose {
+            jobs.forEach { it.cancel() }
+            commandManager.stopImuData()
+            commandManager.closeCanvas()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        // 画面に入った向きを中央のアイコンに合わせる
+        val centerYaw = yaw.filterNotNull().first()
+
+        commandManager.sendCanvas(listOf(descriptionElement(items[focused])))
+        items.forEachIndexed { index, _ ->
+            commandManager.sendCanvasImage(
+                id = index,
+                x = iconX(index, items.size),
+                y = ICON_Y,
+                width = ICON_SIZE,
+                height = ICON_SIZE,
+                grayscale = icons[index].let { if (index == focused) it.second else it.first }.pixels,
+            )
+        }
+
+        while (isActive) {
+            delay(CURSOR_POLL_MS)
+            val next = cursorIndex(yaw.value ?: centerYaw, centerYaw, items.size)
+            if (next == focused) continue
+
+            val previous = focused
+            focused = next
+            commandManager.sendCanvasImage(
+                id = previous,
+                x = iconX(previous, items.size),
+                y = ICON_Y,
+                width = ICON_SIZE,
+                height = ICON_SIZE,
+                grayscale = icons[previous].first.pixels,
+            )
+            commandManager.sendCanvasImage(
+                id = next,
+                x = iconX(next, items.size),
+                y = ICON_Y,
+                width = ICON_SIZE,
+                height = ICON_SIZE,
+                grayscale = icons[next].second.pixels,
+            )
+            commandManager.sendCanvasElements(listOf(descriptionElement(items[next])))
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("ランチャー") }) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(
+                "首を振ってカーソルを動かし、グラスのシングルタップで選ぶ。" +
+                    "隣に移るまで${STEP_DEGREES.toInt()}度。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                items.forEachIndexed { index, item ->
+                    val icon = icons[index].let { if (index == focused) it.second else it.first }
+                    Image(
+                        bitmap = icon.toBitmap().asImageBitmap(),
+                        contentDescription = item.label,
+                        modifier = Modifier.size(72.dp),
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(items[focused].label, style = MaterialTheme.typography.titleMedium)
+            Text(items[focused].description, style = MaterialTheme.typography.bodyMedium)
+
+            HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+            OutlinedButton(
+                onClick = { onSelect(items[focused]) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("${items[focused].label}をひらく")
+            }
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("戻る")
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+private fun descriptionElement(item: LauncherItem) = CommandManager.CanvasElement(
+    id = 0,
+    x = TEXT_X,
+    y = TEXT_Y,
+    width = TEXT_WIDTH,
+    height = TEXT_HEIGHT,
+    text = "${item.label}\n${item.description}",
+)
+
+private fun iconX(index: Int, count: Int): Int {
+    val row = count * ICON_SIZE + (count - 1) * ICON_GAP
+    return (CANVAS_WIDTH - row) / 2 + index * (ICON_SIZE + ICON_GAP)
+}
+
+private fun cursorIndex(currentYaw: Float, centerYaw: Float, count: Int): Int {
+    val steps = (-normalizeDegrees(currentYaw - centerYaw) / STEP_DEGREES).roundToInt()
+    return (count / 2 + steps).coerceIn(0, count - 1)
+}
+
+/**
+ * アイコンを2値で描く。グラスは3bitに量子化するので、中間の階調は残さない。
+ * フォーカスは白地に黒抜きの太枠で、絵柄そのものに含める。
+ */
+private fun iconImage(glyph: String, focused: Boolean, size: Int = ICON_SIZE): GrayscaleImage {
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val ink = if (focused) Color.BLACK else Color.WHITE
+    canvas.drawColor(if (focused) Color.WHITE else Color.BLACK)
+
+    val border = Paint().apply {
+        color = ink
+        style = Paint.Style.STROKE
+        strokeWidth = if (focused) 8f else 3f
+        isAntiAlias = false
+    }
+    val inset = border.strokeWidth / 2
+    canvas.drawRect(inset, inset, size - inset, size - inset, border)
+
+    val text = Paint().apply {
+        color = ink
+        textSize = size * 0.55f
+        textAlign = Paint.Align.CENTER
+        isAntiAlias = false
+    }
+    canvas.drawText(glyph, size / 2f, size / 2f - (text.descent() + text.ascent()) / 2f, text)
+
+    val colors = IntArray(size * size)
+    bitmap.getPixels(colors, 0, size, 0, 0, size, size)
+    // 2値にしておけばRLEがよく効いて、差し替えの転送も短くなる
+    val pixels = ByteArray(colors.size) { index ->
+        if (Color.red(colors[index]) >= 128) 0xFF.toByte() else 0x00
+    }
+    return GrayscaleImage(size, size, pixels)
+}

--- a/samples/kmp/settings.gradle.kts
+++ b/samples/kmp/settings.gradle.kts
@@ -12,6 +12,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // ローカル検証用。publishToMavenLocal した SDK を先に見る
+        mavenLocal()
         // 認証情報は名前から決まる GitHubPackagesUsername / GitHubPackagesPassword を
         // Gradle が探す。設定キャッシュには保存されず、必要になるまで要求もされない。
         maven {

--- a/samples/kmp/settings.gradle.kts
+++ b/samples/kmp/settings.gradle.kts
@@ -12,8 +12,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // ローカル検証用。publishToMavenLocal した SDK を先に見る
-        mavenLocal()
         // 認証情報は名前から決まる GitHubPackagesUsername / GitHubPackagesPassword を
         // Gradle が探す。設定キャッシュには保存されず、必要になるまで要求もされない。
         maven {


### PR DESCRIPTION
## 概要

- グラスの入力（6DoF・ジェスチャー）と出力（テキスト・画像・キャンバス）を、遊びながら確かめられるサンプル画面を追加する
- 1枚ずつ画像を差し替える方法と、0.8.1 で入ったキャンバスのアニメーションを、同じデータで見比べられるようにする
- アニメと静的な画像が同時に置けないことが、触ってすぐ分かるようにする

追加した画面

| 画面 | 使う API |
|---|---|
| かわくだり | 6DoF のヨー + 汎用テキスト表示 |
| ランチャー | 6DoF のヨーとピッチ + キャンバス（画像・テキスト） + シングルタップ |
| アスキーアートを流す | 汎用テキスト表示を毎コマ置き換え |
| 2値画像を流す | 画像表示ページを毎コマ置き換え |
| キャンバスに動画を流す | キャンバスのアニメーション（寸法と interval を可変） |
| 自由配置キャンバス（既存） | 静止画・動画・テキストを1画面に並べるデモを追加 |

## アニメーションのデータについて

データはリポジトリに含めていない。`samples/kmp/app/src/main/assets/` に次の形式で置くと読み込まれる。

| ファイル | 形式 |
|---|---|
| `animation-20x8.txt` | 1コマ8行・各行20文字のアスキーアートを、コマの順に連結したテキスト |
| `animation-96x72.bin` | 96×72 を1画素1bit（MSBが左端・行優先）に詰めて、コマの順に連結したバイナリ |
| `animation-320x240.bin` | 320×240 を同じ形式で連結したバイナリ |

動画から作る場合は、グレースケールに落として閾値で2値化し、上の形式に詰めればよい。手元では ffmpeg と短いスクリプトで用意した。

データが無いときは動画系の3画面が読み込みエラーを表示するだけで、他の画面には影響しない。

## 関連リンク

- Asana: 未紐付け（対話の中で出た作業のため、該当タスクなし）

## 動作確認

- [x] かわくだり: 首の向きで自機が動き、衝突の直前で止まってリザルトに移る（Pixel 8a + 実機グラス）
- [x] ランチャー: ヨーで列、ピッチで段が動き、シングルタップで各画面に飛ぶ
- [x] キャンバスに動画を流す: 128×96・interval=100ms で約10fps を維持
- [x] 静止画・動画・テキストを1コマに合成して並べる
- [x] アスキーアート版・2値画像版のコマ落ちの見え方
- [x] アニメ中の clearCanvas / 切断 / ナビとの行き来

🤖 Generated with [Claude Code](https://claude.com/claude-code)