### PR TITLE
🆙 サンプルの参照する SDK を 0.8.3 にして pre-release 回避を外す

### DIFF
--- a/docs/api-history.md
+++ b/docs/api-history.md
@@ -10,6 +10,15 @@ nav_order: 6
 配布しているのは Android のみで、iOS は 0.0.10 で止まっている。iOS で使えるのは
 0.0.10 時点の API までになる。
 
+## 0.8.3
+
+メソッドの追加は無い。ビルド上の変更のみ。
+
+- 成果物が pre-release 扱いにならなくなった。0.8.2 以前で必要だった `-Xskip-prerelease-check` は不要
+- `GlassConnection` インターフェースと `PickerUnavailableException` が aar に残るようになり、接続管理を `GlassManager` 具象型ではなく `GlassConnection` で受けられる
+
+（0.8.2 は publish に失敗しており存在しない）
+
 ## 0.8.1
 
 | メソッド | 補足 |

--- a/docs/api-history.md
+++ b/docs/api-history.md
@@ -14,7 +14,7 @@ nav_order: 6
 
 メソッドの追加は無い。ビルド上の変更のみ。
 
-- 成果物が pre-release 扱いにならなくなった。0.8.2 以前で必要だった `-Xskip-prerelease-check` は不要
+- 成果物が pre-release 扱いにならなくなった。0.8.1 以前で必要だった `-Xskip-prerelease-check` は不要
 - `GlassConnection` インターフェースと `PickerUnavailableException` が aar に残るようになり、接続管理を `GlassManager` 具象型ではなく `GlassConnection` で受けられる
 
 ## 0.8.1

--- a/docs/api-history.md
+++ b/docs/api-history.md
@@ -17,8 +17,6 @@ nav_order: 6
 - 成果物が pre-release 扱いにならなくなった。0.8.2 以前で必要だった `-Xskip-prerelease-check` は不要
 - `GlassConnection` インターフェースと `PickerUnavailableException` が aar に残るようになり、接続管理を `GlassManager` 具象型ではなく `GlassConnection` で受けられる
 
-（0.8.2 は publish に失敗しており存在しない）
-
 ## 0.8.1
 
 | メソッド | 補足 |

--- a/samples/flutter/android/app/build.gradle.kts
+++ b/samples/flutter/android/app/build.gradle.kts
@@ -18,7 +18,6 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-            freeCompilerArgs.add("-Xskip-prerelease-check")
         }
     }
 
@@ -42,6 +41,6 @@ flutter {
 }
 
 dependencies {
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.7.3")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/samples/kmp/app/build.gradle.kts
+++ b/samples/kmp/app/build.gradle.kts
@@ -24,7 +24,6 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-            freeCompilerArgs.add("-Xskip-prerelease-check")
         }
     }
 
@@ -38,7 +37,7 @@ android {
 
 dependencies {
     // Sabera App SDK
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.1")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     // Compose

--- a/samples/kmp/snippets/build.gradle.kts
+++ b/samples/kmp/snippets/build.gradle.kts
@@ -22,12 +22,11 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-            freeCompilerArgs.add("-Xskip-prerelease-check")
         }
     }
 }
 
 dependencies {
-    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.7.3")
+    implementation("jp.jig.sabera.app.sdk:sabera-app-core:0.8.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }


### PR DESCRIPTION
## 概要
SDK 0.8.3（jig-jp/jig-glass#1765, #1766 を含む）が publish されたので追従する。

## 変更内容
- kmp/app（0.8.1）・kmp/snippets（0.7.3）・flutter（0.7.3）の依存を 0.8.3 に統一
- 3 サンプルから `-Xskip-prerelease-check` を除去（SDK 側で実験的コンパイラフラグを外したため不要）
- `docs/api-history.md` に 0.8.3 を追記（メソッド追加なし。pre-release 解消、`GlassConnection` / `PickerUnavailableException` が aar に残るようになった、0.8.2 は publish 失敗で存在しない）

## 確認
`samples/kmp` で `:snippets:compileDebugKotlin :snippets:ktlintCheck :app:compileDebugKotlin` が回避フラグなしで green（JDK 21 / Gradle 8.10.2）。Flutter サンプルは Flutter 環境が無いため未ビルド。

🤖 Generated with [Claude Code](https://claude.com/claude-code)